### PR TITLE
fix(Hipercool): Add browser-like headers to bypass Cloudflare

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hipercool.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Hipercool.kt
@@ -1,7 +1,9 @@
 package org.koitharu.kotatsu.parsers.site.madara.pt
 
+import okhttp3.Headers
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.config.ConfigKey
 import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
@@ -9,5 +11,26 @@ import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 @MangaSourceParser("HIPERCOOL", "Hipercool", "pt", ContentType.HENTAI)
 internal class Hipercool(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.HIPERCOOL, "hiper.cool", pageSize = 20) {
+
 	override val tagPrefix = "manga-tag/"
+
+	override fun onCreateConfig(keys: MutableCollection<ConfigKey<*>>) {
+		super.onCreateConfig(keys)
+		keys.add(userAgentKey)
+	}
+
+	override fun getRequestHeaders(): Headers = Headers.Builder()
+		.add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7")
+		.add("Accept-Language", "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7")
+		.add("Cache-Control", "max-age=0")
+		.add("Connection", "keep-alive")
+		.add("Sec-Ch-Ua", "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"")
+		.add("Sec-Ch-Ua-Mobile", "?0")
+		.add("Sec-Ch-Ua-Platform", "\"Windows\"")
+		.add("Sec-Fetch-Dest", "document")
+		.add("Sec-Fetch-Mode", "navigate")
+		.add("Sec-Fetch-Site", "none")
+		.add("Sec-Fetch-User", "?1")
+		.add("Upgrade-Insecure-Requests", "1")
+		.build()
 }


### PR DESCRIPTION
## Summary
Added custom browser-like headers to the HipercooL parser to help bypass Cloudflare protection that was causing VPN-like errors.

## Problem
Users were reporting "VPN error" messages when accessing the source through Kotatsu, while the site worked normally in Chrome browser. This is due to Cloudflare detecting the app's requests as non-browser/automated traffic.

## Changes
- Added `onCreateConfig()` to expose the User-Agent configuration option
- Added `getRequestHeaders()` override with full browser-like headers:
  - `Accept` with standard browser accept types
  - `Accept-Language` with Portuguese (Brazil) locale
  - `Cache-Control` and `Connection` headers
  - `Sec-Ch-Ua` client hints mimicking Chrome
  - `Sec-Fetch-*` headers for proper navigation context
  - `Upgrade-Insecure-Requests` header

## Technical Details
The headers are designed to make requests appear as legitimate browser navigation rather than automated API calls, which should reduce Cloudflare challenges.

## Issue Reference
Addresses user report of VPN error on HipercooL source

## Testing
- [x] Build compiles successfully
- [ ] Manual testing needed by users experiencing the issue

## Note
If this doesn't fully resolve the issue, users may still need to:
1. Open WebView and complete any Cloudflare challenge manually
2. Clear cookies/cache for this source
3. Try different User-Agent settings