### PR TITLE
[Kiryuu] Fix page loading and add domain mirrors

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/natsu/id/Kiryuu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/natsu/id/Kiryuu.kt
@@ -3,11 +3,37 @@ package org.koitharu.kotatsu.parsers.site.natsu.id
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
+import org.koitharu.kotatsu.parsers.model.MangaPage
+import org.koitharu.kotatsu.parsers.model.MangaChapter
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.natsu.NatsuParser
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.parsers.util.parseHtml
+import org.koitharu.kotatsu.parsers.util.requireSrc
+import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
+import org.koitharu.kotatsu.parsers.util.toRelativeUrl
 
 @MangaSourceParser("KIRYUU", "Kiryuu", "id")
 internal class Kiryuu(context: MangaLoaderContext) :
-    NatsuParser(context, MangaParserSource.KIRYUU, pageSize = 24) {
-    override val configKeyDomain = ConfigKey.Domain("kiryuu03.com")
+	NatsuParser(context, MangaParserSource.KIRYUU, pageSize = 24) {
+	override val configKeyDomain = ConfigKey.Domain(
+		"kiryuu03.com",
+		"kiryuu04.com",
+		"kiryuu05.com",
+		"kiryuu.id",
+	)
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val doc = webClient.httpGet(chapter.url.toAbsoluteUrl(domain)).parseHtml()
+		// Images are in a section with data-image-data attribute
+		return doc.select("section[data-image-data] img").map { img ->
+			val url = img.requireSrc().toRelativeUrl(domain)
+			MangaPage(
+				id = generateUid(url),
+				url = url,
+				preview = null,
+				source = source,
+			)
+		}
+	}
 }


### PR DESCRIPTION
Issues found:
ERROR (Page Loading): The base parser's image selector main section section > img wasn't matching the site's current structure. Fixed with a more specific selector section[data-image-data] img that targets the reader section directly.

LAG (Slow Updates): This is server-side and cannot be fully fixed in the parser. The site returns ALL chapters in a single request (e.g., Martial Peak has 3800+ chapters returned at once, taking ~8+ seconds to download and parse). The parser already handles pagination correctly, but the server ignores pagination and dumps everything in one response.
Changes made:

Override getPages() with correct selector for Kiryuu's reader structure
Added domain mirrors: kiryuu04.com, kiryuu05.com, kiryuu.id