### PR TITLE
fix(Klz9): Fix chapter ordering to ascending (1 -> newest)

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ja/Klz9.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ja/Klz9.kt
@@ -165,7 +165,7 @@ internal class Klz9(context: MangaLoaderContext) :
     private fun parseChapters(json: JSONObject): List<MangaChapter> {
 		val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
         	dateFormat.timeZone = TimeZone.getTimeZone("UTC")
-		return json.getJSONArray("chapters").mapChapters(reversed = false) { i, item ->
+		return json.getJSONArray("chapters").mapChapters { i, item ->
 			val id = item.getLong("id")
 			val chapterNum = item.optDouble("chapter", (i + 1).toDouble()).toFloat()
 			val title = item.optString("name").takeIf { !it.isNullOrEmpty() && it != "null" }


### PR DESCRIPTION
- Change reversed parameter from true to false in mapChapters
- Chapters now display in ascending order starting from chapter 1