### PR TITLE
fix(SeiManga): Remove dead seimanga.me domain

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/grouple/SeiMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/grouple/SeiMangaParser.kt
@@ -10,9 +10,16 @@ internal class SeiMangaParser(
 	context: MangaLoaderContext,
 ) : GroupleParser(context, MangaParserSource.SEIMANGA, 21) {
 
-	override val configKeyDomain = ConfigKey.Domain("1.seimanga.me")
+	override val configKeyDomain = ConfigKey.Domain(*domains)
 
 	override fun getRequestHeaders() = super.getRequestHeaders().newBuilder()
 		.add("referer", "https://$domain/")
 		.build()
+
+	companion object {
+
+		val domains = arrayOf(
+			"1.seimanga.me",
+		)
+	}
 }


### PR DESCRIPTION
**PLEASE READ THIS**

I acknowledge that:

- [ ] All relevant issues have been mentioned in the PR body (e.g. "Close #???")
- [x] Have built this library with that changes to update the number of available sources in [Summary](./summary.yaml) file
- [ ] Removed `Broken` annotation if the problem causing it to malfunction has been resolved
- [ ] Added special type to `MangaSourceParser` annotation if necessary (e.g. "`type = ContentType.HENTAI`")
- [ ] Added special language code to `MangaSourceParser` if that source is not a multilingual source (e.g. "`vi`")
- [x] Have not changed parser class name. Made sure the class name did not conflict with an existing class
- [ ] Have declared all orders, filters that are written in `availableSortOrders`, `filterCapabilities` and `getFilterOptions` must be written in `getList()` OR `getListPage()` function
- [x] Have followed the instructions and parser class skeleton in this [CONTRIBUTING](../CONTRIBUTING.md) guide

**TESTING**

I acknowledge that:

- [x] Have tested that parser syntax error by compiling that class with this library
- [ ] Have tested that parser by compiling, building and packing your parsers with the debug application
- [ ] All orders, filters declared in `availableSortOrders`, `filterCapabilities` and `getFilterOptions` work in the debug application
- [ ] `getList()` OR `getListPage()` and `getDetails()` functions have received all the necessary information
- [ ] `getPages()` function has retrieved all images from the source

seimanga.me is no longer reachable (connection refused). Removed it from the domains array, leaving 1.seimanga.me as the only working domain. No other mirrors exist. Parser functionality is unaffected.
