### PR TITLE
fix(TeamXNovel): Invalid CSS selector in parseChapters

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ar/TeamXNovel.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ar/TeamXNovel.kt
@@ -146,7 +146,7 @@ internal class TeamXNovel(context: MangaLoaderContext) :
 		val maxPageChapterSelect = doc.select(".pagination .page-item a")
 		var maxPageChapter = 1
 		if (!maxPageChapterSelect.isNullOrEmpty()) {
-			maxPageChapterSelect.map {
+			maxPageChapterSelect.forEach {
 				val i = it.attr("href").substringAfterLast("=").toInt()
 				if (i > maxPageChapter) {
 					maxPageChapter = i
@@ -175,7 +175,7 @@ internal class TeamXNovel(context: MangaLoaderContext) :
 					coroutineScope {
 						val result = ArrayList(parseChapters(doc))
 						result.ensureCapacity(result.size * maxPageChapter)
-						(2..maxPageChapter).map { i ->
+						(2 downTo maxPageChapter).map { i ->
 							async {
 								loadChapters(mangaUrl, i)
 							}
@@ -192,20 +192,18 @@ internal class TeamXNovel(context: MangaLoaderContext) :
 		return parseChapters(webClient.httpGet("$baseUrl?page=$page").parseHtml().body())
 	}
 
-	private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", sourceLocale)
-
 	private fun parseChapters(root: Element): List<MangaChapter> {
-		return root.requireElementById("chapter-contact").select(".eplister ul li")
-			.map { li ->
-				val url = li.selectFirstOrThrow("a").attrAsRelativeUrl("href")
+		return root.requireElementById("chaptersContainer").select(".chapter-card")
+			.map { div ->
+				val url = div.selectFirstOrThrow("a").attrAsRelativeUrl("href")
 				MangaChapter(
 					id = generateUid(url),
-					title = li.selectFirstOrThrow(".epl-title").text(),
+					title = div.selectFirstOrThrow(".chapter-title").text(),
 					number = url.substringAfterLast('/').toFloatOrNull() ?: 0f,
 					volume = 0,
 					url = url,
 					scanlator = null,
-					uploadDate = dateFormat.parseSafe(li.selectFirstOrThrow(".epl-date").text()),
+					uploadDate = parseChapterDate(div.selectFirstOrThrow(".chapter-date span").text()),
 					branch = null,
 					source = source,
 				)
@@ -220,13 +218,59 @@ internal class TeamXNovel(context: MangaLoaderContext) :
 				img.hasAttr("src") -> img.requireSrc().toRelativeUrl(domain)
 				else -> img.attrAsRelativeUrl("data-src")
 			}
-			
+
 			MangaPage(
 				id = generateUid(url),
 				url = url,
 				preview = null,
 				source = source,
 			)
+		}
+	}
+
+	private fun parseChapterDate(dateText: String?): Long {
+		if (dateText == null) return 0
+
+		val relativeTimePattern = Regex("(\\d+)\\s*(phút|giờ|ngày|tuần) trước")
+		val absoluteTimePattern = Regex("(\\d{2}-\\d{2}-\\d{4})")
+
+		return when {
+			dateText.contains("minute") -> {
+				val match = relativeTimePattern.find(dateText)
+				val minutes = match?.groups?.get(1)?.value?.toIntOrNull() ?: 0
+				System.currentTimeMillis() - minutes * 60 * 1000
+			}
+
+			dateText.contains("hour") -> {
+				val match = relativeTimePattern.find(dateText)
+				val hours = match?.groups?.get(1)?.value?.toIntOrNull() ?: 0
+				System.currentTimeMillis() - hours * 3600 * 1000
+			}
+
+			dateText.contains("day") -> {
+				val match = relativeTimePattern.find(dateText)
+				val days = match?.groups?.get(1)?.value?.toIntOrNull() ?: 0
+				System.currentTimeMillis() - days * 86400 * 1000
+			}
+
+			dateText.contains("week") -> {
+				val match = relativeTimePattern.find(dateText)
+				val weeks = match?.groups?.get(1)?.value?.toIntOrNull() ?: 0
+				System.currentTimeMillis() - weeks * 7 * 86400 * 1000
+			}
+
+			dateText.contains("year") -> {
+				val match = relativeTimePattern.find(dateText)
+				val years = match?.groups?.get(1)?.value?.toIntOrNull() ?: 0
+				System.currentTimeMillis() - years * 365L * 86400 * 1000
+			}
+
+			absoluteTimePattern.matches(dateText) -> {
+				val formatter = SimpleDateFormat("dd-MM-yyyy", Locale.getDefault())
+				formatter.parseSafe(dateText)
+			}
+
+			else -> 0L
 		}
 	}
 }


### PR DESCRIPTION
**PLEASE READ THIS**

I confirm that:

- [x] All relevant issues have been mentioned in the PR description (e.g., "Closes #???")
- [ ] I have built the library with these changes to update the number of available sources in the [Summary](https://github.com/YakaTeam/kotatsu-parsers/blob/master/.github/summary.yaml) file
- [ ] I have removed `@Broken` annotation if the issue causing it to malfunction has been resolved
- [ ] I have added a special type to `MangaSourceParser` annotation if necessary (e.g., "`type = ContentType.HENTAI`")
- [ ] I have added a specific language code to `MangaSourceParser` annotation if the source is not multilingual (e.g., `vi`)
- [x] I have not changed the parser class name and ensured it does not conflict with any existing class
- [ ] All declared sort orders and filters in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` are properly implemented in `getList()` OR `getListPage()` function
- [x] I have followed the instructions and parser class skeleton provided in [this CONTRIBUTING guide](https://github.com/YakaTeam/kotatsu-parsers/blob/master/CONTRIBUTING.md)
- [x] This PR only creates / edits to a single source; any more than that will be automatically rejected by reviewers

**TESTING**

I confirm that:

- [x] I have tested the parser for syntax errors by compiling the class with the library
- [x] I have tested the parser by compiling, building, and packaging it with the debug application
- [ ] All sort orders and filters declared in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` work correctly in the debug application
- [x] `getList()` OR `getListPage()` and `getDetails()` functions retrieve all necessary information
- [x] `getPages()` function successfully retrieves all images from the source

> [!IMPORTANT]
> - You must provide accurate information before creating a pull request
> - Select only the tasks you have completed and leave blank if you haven't done them
> - This information will be verified against data retrieved from that source by the reviewers.

---

### Source Name (Language)

TeamXNovel

### Related Issues

Close #180

### Description

N/A
