### PR TITLE
Fix MangaClash

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangaclash.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/Mangaclash.kt
@@ -5,8 +5,8 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-@MangaSourceParser("MANGACLASH", "ToonClash", "en")
+@MangaSourceParser("MANGACLASH", "MangaClash", "en")
 internal class Mangaclash(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.MANGACLASH, "toonclash.com", pageSize = 18) {
+	MadaraParser(context, MangaParserSource.MANGACLASH, "mangaclash.com", pageSize = 18) {
 	override val datePattern = "MM/dd/yyyy"
 }


### PR DESCRIPTION
**PLEASE READ THIS**

I confirm that:

- [ ] All relevant issues have been mentioned in the PR description (e.g., "Closes #???")
- [ ] I have built the library with these changes to update the number of available sources in the [Summary](https://github.com/YakaTeam/kotatsu-parsers/blob/master/.github/summary.yaml) file
- [ ] I have removed `@Broken` annotation if the issue causing it to malfunction has been resolved
- [ ] I have added a special type to `MangaSourceParser` annotation if necessary (e.g., "`type = ContentType.HENTAI`")
- [ ] I have added a specific language code to `MangaSourceParser` annotation if the source is not multilingual (e.g., `vi`)
- [ ] I have not changed the parser class name and ensured it does not conflict with any existing class
- [ ] All declared sort orders and filters in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` are properly implemented in `getList()` OR `getListPage()` function
- [X] I have followed the instructions and parser class skeleton provided in [this CONTRIBUTING guide](https://github.com/YakaTeam/kotatsu-parsers/blob/master/CONTRIBUTING.md)
- [X] This PR only creates / edits to a single source; any more than that will be automatically rejected by reviewers

**TESTING**

I confirm that:

- [X] I have tested the parser for syntax errors by compiling the class with the library
- [X] I have tested the parser by compiling, building, and packaging it with the debug application
- [ ] All sort orders and filters declared in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` work correctly in the debug application
- [X] `getList()` OR `getListPage()` and `getDetails()` functions retrieve all necessary information
- [X] `getPages()` function successfully retrieves all images from the source

> [!IMPORTANT]
> - You must provide accurate information before creating a pull request
> - Select only the tasks you have completed and leave blank if you haven't done them
> - This information will be verified against data retrieved from that source by the reviewers.

---

### Source Name (Language)

MangaClash (en)

### Related Issues

N/A

### Description

Updated the mangaclash domain url to fix it not loading.
