### PR TITLE
fix(WestManga): migrate parser to new westmanga.tv backend

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/WestmangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/WestmangaParser.kt
@@ -4,7 +4,6 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.json.JSONObject
 import org.jsoup.Jsoup
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.core.AbstractMangaParser
@@ -15,18 +14,16 @@ import org.koitharu.kotatsu.parsers.util.*
 import org.koitharu.kotatsu.parsers.util.json.asTypedList
 import org.koitharu.kotatsu.parsers.util.json.mapJSON
 import org.koitharu.kotatsu.parsers.util.json.mapJSONToSet
-import java.text.SimpleDateFormat
 import java.util.*
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-@Broken
 @MangaSourceParser("WESTMANGA", "WestManga", "id")
 internal class WestmangaParser(context: MangaLoaderContext) :
     AbstractMangaParser(context, MangaParserSource.WESTMANGA) {
 
     override val configKeyDomain = ConfigKey.Domain("westmanga.tv")
-	private val apiUrl = "https://data.westmanga.me"
+	private val apiUrl get() = "https://data.$domain"
 
     override val availableSortOrders: Set<SortOrder> = setOf(
         SortOrder.UPDATED,
@@ -46,27 +43,31 @@ internal class WestmangaParser(context: MangaLoaderContext) :
     )
 
     override suspend fun getList(offset: Int, order: SortOrder, filter: MangaListFilter): List<Manga> {
-        val page = (offset / 20) + 1
+        val page = (offset / PAGE_SIZE) + 1
 
         val urlBuilder = "$apiUrl/api/contents".toHttpUrl().newBuilder()
-            .addQueryParameter("page", page.toString())
-            .addQueryParameter("per_page", 20.toString())
-            .addQueryParameter("type", "Comic")
 
         if (!filter.query.isNullOrBlank()) {
             urlBuilder.addQueryParameter("q", filter.query)
-        } else {
+        }
+
+        urlBuilder.addQueryParameter("page", page.toString())
+        urlBuilder.addQueryParameter("per_page", PAGE_SIZE.toString())
+
+        if (filter.query.isNullOrBlank()) {
             val orderBy = when (order) {
                 SortOrder.POPULARITY -> "Popular"
                 SortOrder.UPDATED -> "Update"
                 SortOrder.NEWEST -> "Added"
                 SortOrder.ALPHABETICAL -> "Az"
-                else -> "Default"
+                else -> null
             }
-            if (orderBy != "Default") {
+            if (orderBy != null) {
                 urlBuilder.addQueryParameter("orderBy", orderBy)
             }
         }
+
+        urlBuilder.addQueryParameter("project", "false")
 
         if (filter.tags.isNotEmpty()) {
 			filter.tags.forEach {
@@ -86,11 +87,11 @@ internal class WestmangaParser(context: MangaLoaderContext) :
 
         return manga.copy(
             title = json.getString("title"),
-            description = json.optString("synopsis", "").let { Jsoup.parse(it).text() },
-            coverUrl = json.getString("cover"),
-            authors = setOfNotNull(json.optString("author")),
+            description = json.optString("sinopsis", json.optString("synopsis", "")).let { Jsoup.parse(it).text() },
+            coverUrl = json.optString("cover").ifBlank { manga.coverUrl.orEmpty() },
+            authors = setOfNotNull(json.optString("author").takeIf { it.isNotBlank() }),
             state = parseStatus(json.optString("status")),
-            chapters = parseChapters(json.getJSONArray("chapters"))
+            chapters = parseChapters(json.getJSONArray("chapters")),
         )
     }
 
@@ -99,13 +100,13 @@ internal class WestmangaParser(context: MangaLoaderContext) :
         val url = "$apiUrl/api/v/$slug"
         val json = apiRequest(url).getJSONObject("data")
         return json.getJSONArray("images").asTypedList<String>().map {
-			MangaPage(
-				id = it.toLong(),
-				url = it,
-				preview = null,
-				source = source
-			)
-		}
+				MangaPage(
+					id = generateUid(it),
+					url = it,
+					preview = null,
+					source = source,
+				)
+			}
     }
 
     private fun parseManga(json: JSONObject): Manga {
@@ -114,15 +115,15 @@ internal class WestmangaParser(context: MangaLoaderContext) :
             id = slug.longHashCode(),
             title = json.getString("title"),
             altTitles = emptySet(),
-            url = "/manga/$slug",
-            publicUrl = "$domain/manga/$slug",
+            url = "/comic/$slug",
+            publicUrl = "https://$domain/comic/$slug",
             rating = RATING_UNKNOWN,
             contentRating = sourceContentRating,
-            coverUrl = json.getString("cover"),
+            coverUrl = json.optString("cover"),
             tags = emptySet(),
-            state = null,
+            state = parseStatus(json.optString("status")),
             authors = emptySet(),
-            source = source
+            source = source,
         )
     }
 
@@ -130,42 +131,34 @@ internal class WestmangaParser(context: MangaLoaderContext) :
         val chapters = mutableListOf<MangaChapter>()
         for (i in 0 until array.length()) {
             val item = array.getJSONObject(i)
+			val chapterSlug = item.getString("slug")
             chapters.add(MangaChapter(
-                id = item.getString("slug").longHashCode(),
+                id = chapterSlug.longHashCode(),
                 title = "Chapter ${item.optString("number")}",
                 number = item.optString("number").toFloatOrNull() ?: 0f,
                 volume = 0,
-                url = "/${item.getString("slug")}",
+                url = "/view/$chapterSlug",
                 scanlator = null,
-                uploadDate = parseDate(item.optString("updated_at")),
+                uploadDate = parseDate(item.optJSONObject("updated_at")),
                 branch = null,
-                source = source
+                source = source,
             ))
         }
         return chapters.reversed()
     }
 
-    private fun parseStatus(status: String): MangaState {
+    private fun parseStatus(status: String): MangaState? {
         return when (status.lowercase(Locale.ROOT)) {
             "ongoing" -> MangaState.ONGOING
             "completed" -> MangaState.FINISHED
             "hiatus" -> MangaState.PAUSED
-            else -> MangaState.ONGOING
+            else -> null
         }
     }
 
-    private fun parseDate(dateStr: String): Long {
-        // Try parsing as timestamp (long/string)
-        dateStr.toLongOrNull()?.let { return it * 1000 }
-
-        // Try parsing as ISO string
-        try {
-            val format = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
-            format.timeZone = TimeZone.getTimeZone("UTC") // API often returns UTC or server time.
-            return format.parseSafe(dateStr)
-        } catch (_: Exception) {
-            return 0L
-        }
+    private fun parseDate(updatedAt: JSONObject?): Long {
+        val seconds = updatedAt?.optLong("time", 0L) ?: 0L
+        return if (seconds > 0) seconds * 1000 else 0L
     }
 
     private suspend fun fetchTags(): Set<MangaTag> {
@@ -180,7 +173,6 @@ internal class WestmangaParser(context: MangaLoaderContext) :
 		}
     }
 
-	// I have no idea about it ¯\_(ツ)_/¯
     private suspend fun apiRequest(url: String): JSONObject {
         val timestamp = (System.currentTimeMillis() / 1000).toString()
         val message = "wm-api-request"
@@ -194,7 +186,8 @@ internal class WestmangaParser(context: MangaLoaderContext) :
         val signature = hash.joinToString("") { "%02x".format(it) }
 
         val headers = Headers.Builder()
-            .add(CommonHeaders.REFERER, "$domain/")
+            .add(CommonHeaders.REFERER, "https://$domain/")
+            .add(CommonHeaders.ORIGIN, "https://$domain")
             .add(CommonHeaders.X_WM_REQUEST_TIME, timestamp)
             .add(CommonHeaders.X_WM_ACCESS_KEY, ACCESS_KEY)
             .add(CommonHeaders.X_WM_REQUEST_SIGNATURE, signature)
@@ -208,5 +201,6 @@ internal class WestmangaParser(context: MangaLoaderContext) :
 	companion object {
 		private const val ACCESS_KEY = "WM_WEB_FRONT_END"
 		private const val SECRET_KEY = "xxxoidj"
+		private const val PAGE_SIZE = 40
 	}
 }

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/WestmangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/id/WestmangaParser.kt
@@ -4,6 +4,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.json.JSONObject
 import org.jsoup.Jsoup
+import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.core.AbstractMangaParser
@@ -19,12 +20,13 @@ import java.util.*
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
+@Broken
 @MangaSourceParser("WESTMANGA", "WestManga", "id")
 internal class WestmangaParser(context: MangaLoaderContext) :
     AbstractMangaParser(context, MangaParserSource.WESTMANGA) {
 
-    override val configKeyDomain = ConfigKey.Domain("westmanga.me")
-	private val apiUrl = "https://data.$domain"
+    override val configKeyDomain = ConfigKey.Domain("westmanga.tv")
+	private val apiUrl = "https://data.westmanga.me"
 
     override val availableSortOrders: Set<SortOrder> = setOf(
         SortOrder.UPDATED,


### PR DESCRIPTION
Site was rebuilt as a React-Router SPA at **westmanga.tv** with a new signed-request API at **data.westmanga.tv**. The HMAC signing scheme and access/secret key pair are unchanged from the previous backend, but several paths, params, and the API host itself moved.

## Fixes

- API host now resolves from `configKeyDomain` (was hardcoded to `data.westmanga.me`)
- List endpoint drops `type=Comic` - now uses `project=true/false`
- Page size raised from 20 to 40 to match the site's own pagination
- Manga public path is `/comic/{slug}` (was `/manga/{slug}`)
- Chapter reader path is `/view/{chapter-slug}` (was `/{chapter-slug}`)
- Chapter `updated_at` is now a nested object `{time, formatted}` instead of a string
- `Origin` header is required by the new CORS policy
- Status is also available on list items, so populate it there too
- `MangaPage.id` now uses `generateUid(url)` instead of `url.toLong()` (URL is no longer numeric)
- `parseStatus` returns nullable instead of defaulting to ONGOING for unknown states
- Drops `@Broken` marker - parser is verified working end-to-end

## Verification

Intercepted real network traffic from `westmanga.tv` via headless Chrome. The new API reuses the old HMAC-SHA256 scheme (signed path only, no query), the same `ACCESS_KEY=WM_WEB_FRONT_END`, and the same `SECRET_KEY=xxxoidj`. Confirmed by live-calling `data.westmanga.tv/api/contents?page=1&per_page=40&orderBy=Update&project=false` - returns 200 with populated JSON. Two signature variants were tested and only path-only signing (the existing approach) returned 200.

Closes #240