### PR TITLE
fix(ErosScans): migrate to scythescans.com

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ErosScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/ErosScans.kt
@@ -7,4 +7,4 @@ import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
 @MangaSourceParser("EROSSCANS", "ErosScans", "en")
 internal class ErosScans(context: MangaLoaderContext) :
-	MangaReaderParser(context, MangaParserSource.EROSSCANS, "erosxscans.xyz", pageSize = 20, searchPageSize = 10)
+	MangaReaderParser(context, MangaParserSource.EROSSCANS, "scythescans.com", pageSize = 20, searchPageSize = 10)


### PR DESCRIPTION
The old `erosxscans.xyz` domain is parked by GoDaddy and only serves a redirect to `/lander`. The reporter's suggested `erosxsun.xyz` 301s to **scythescans.com**, which is the live site actively hosting the full catalog under the same MangaReader/Themesia theme the parser already targets.

## Verification

Verified against `scythescans.com`:

- `/manga/` list renders with `.listupd .bs .bsx` + `img.ts-post-image`
- Series pages have `#chapterlist > ul > li` with the expected layout
- Reader pages expose images via `div#readerarea img`
- Chapter URL format `/<slug>-chapter-<n>/` matches the MangaReader default

No other parser overrides were needed.

Closes #198