### PR TITLE
fix(Iken): tolerate missing "author" field in API list response

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/iken/IkenParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/iken/IkenParser.kt
@@ -105,7 +105,7 @@ internal abstract class IkenParser(
 		return json.getJSONArray("posts").mapJSON {
 			val url = "/series/${it.getString("slug")}"
 			val isNsfwSource = it.getBooleanOrDefault("hot", false)
-			val author = it.getString("author")
+			val author = it.getStringOrNull("author")
 			Manga(
 				id = it.getLong("id"),
 				url = url,


### PR DESCRIPTION
## Root cause

In `IkenParser.parseMangaList`, we do:

```kotlin
val author = it.getString("author")
```

If the API response omits `author`, `getString` throws `JSONException` and the whole list call fails, producing the "no manga loading / empty list" symptom reported as an author issue.

## Verified on 2026-04-18

| API host | `author` key present? |
|---|---|
| `api.vortexscans.org` | ❌ absent |
| `api.hivetoons.org` | ❌ absent |
| `api.magustoon.org` | ✅ present (empty string) |

So the field is being rolled out of the shared Iken backend gradually.

## Fix

`getString("author")` → `getStringOrNull("author")`. When present (current behavior) nothing changes; when absent, the manga surfaces with no author rather than blowing up the entire list.

Side effect: this also unblocks HiveComic (not reported yet, same bug).

Closes #243