### PR TITLE
fix(GourmetScans): decrypt wp-manga protected chapter pages

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/GourmetScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/GourmetScans.kt
@@ -1,9 +1,16 @@
 package org.koitharu.kotatsu.parsers.site.madara.en
 
+import org.json.JSONObject
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.exception.AuthRequiredException
+import org.koitharu.kotatsu.parsers.exception.ParseException
+import org.koitharu.kotatsu.parsers.model.MangaChapter
+import org.koitharu.kotatsu.parsers.model.MangaPage
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
+import org.koitharu.kotatsu.parsers.util.*
+import java.util.Base64
 
 @MangaSourceParser("GOURMETSCANS", "GourmetScans", "en")
 internal class GourmetScans(context: MangaLoaderContext) :
@@ -11,4 +18,62 @@ internal class GourmetScans(context: MangaLoaderContext) :
 	override val listUrl = "project/"
 	override val tagPrefix = "genre/"
 	override val stylePage = ""
+
+	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
+		val fullUrl = chapter.url.toAbsoluteUrl(domain)
+		val doc = webClient.httpGet(fullUrl).parseHtml()
+		val chapterProtector = doc.getElementById("chapter-protector-data")
+		if (chapterProtector == null) {
+			if (doc.selectFirst(selectRequiredLogin) != null) {
+				throw AuthRequiredException(source)
+			}
+			val root = doc.body().selectFirst(selectBodyPage) ?: throw ParseException(
+				"No image found, try to log in",
+				fullUrl,
+			)
+			return root.select(selectPage).map { div ->
+				val img = div.selectFirstOrThrow("img")
+				val url = img.requireSrc().toRelativeUrl(domain)
+				MangaPage(
+					id = generateUid(url),
+					url = url.replace("http:", "https:"),
+					preview = null,
+					source = source,
+				)
+			}
+		}
+
+		val chapterProtectorHtml = chapterProtector.attr("src")
+			.takeIf { it.startsWith("data:text/javascript;base64,") }
+			?.substringAfter("data:text/javascript;base64,")
+			?.let {
+				Base64.getDecoder().decode(it).decodeToString()
+			}
+			?: chapterProtector.html()
+
+		val password = chapterProtectorHtml.substringAfter("wpmangaprotectornonce='").substringBefore("';")
+		val chapterData = JSONObject(
+			chapterProtectorHtml.substringAfter("chapter_data='").substringBefore("';").replace("\\/", "/"),
+		)
+		val unsaltedCiphertext = context.decodeBase64(chapterData.getString("ct"))
+		val salt = chapterData.getString("s").decodeHex()
+		val ciphertext = "Salted__".toByteArray(Charsets.UTF_8) + salt + unsaltedCiphertext
+
+		val rawImgArray = CryptoAES(context).decrypt(context.encodeBase64(ciphertext), password)
+		val imgArrayString = rawImgArray.filterNot { c -> c == '[' || c == ']' || c == '\\' || c == '"' }
+
+		return imgArrayString.split(",").map { url ->
+			MangaPage(
+				id = generateUid(url),
+				url = url.replace("http:", "https:"),
+				preview = null,
+				source = source,
+			)
+		}
+	}
+
+	private fun String.decodeHex(): ByteArray {
+		check(length % 2 == 0) { "Must have an even length" }
+		return chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+	}
 }


### PR DESCRIPTION
Closes #21

## Problem

GourmetScans (`gourmetsupremacy.com`) stopped returning readable chapter pages: the reader HTML now only contains a `<script id="chapter-protector-data">` block that embeds the image URL list as AES-CBC ciphertext produced by the `wp-manga-chapter-images-protection` WordPress plugin. The default Madara `getPages()` selector returns nothing.

## Fix

Override `getPages()` to follow the exact same decryption path already used by `DarkScans` and `AdultWebtoon` for this plugin:

1. Read the `#chapter-protector-data` element (handles both inline and `data:text/javascript;base64,` forms).
2. Extract `wpmangaprotectornonce` (the passphrase) and the `{ct, iv, s}` JSON.
3. Rebuild the OpenSSL `Salted__` prefix ciphertext.
4. Decrypt with the shared `CryptoAES` helper (EVP_BytesToKey key derivation).
5. Parse the resulting JSON array of image URLs.

## Verification

Tested live against `https://gourmetsupremacy.com/project/i-failed-to-divorce-my-husband-manhwa/chapter-100/` — all 18 chapter images decode correctly, e.g. `https://gourmetsupremacy.com/wp-content/uploads/WP-manga/data/manga_631f33e58b6da/951f217b7184a9887954d504a7ec6513/100-(1)_01.jpg`.

Fallback path for unprotected chapters (old selector) is preserved in case some older chapters still render without the plugin.

## Notes

No dependency changes; reuses the existing `CryptoAES` helper. Pattern is line-for-line identical to the two other parsers that already handle this plugin, which should make future maintenance consistent.