### PR TITLE
fix(en/asura): list-card rating/state + pageSize

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/AsuraScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/AsuraScansParser.kt
@@ -18,7 +18,7 @@ import kotlin.collections.emptySet
 
 @MangaSourceParser("ASURASCANS", "AsuraScans", "en")
 internal class AsuraScansParser(context: MangaLoaderContext) :
-	PagedMangaParser(context, MangaParserSource.ASURASCANS, pageSize = 30) {
+	PagedMangaParser(context, MangaParserSource.ASURASCANS, pageSize = 20) {
 
 	override val configKeyDomain = ConfigKey.Domain("asurascans.com")
 
@@ -110,19 +110,18 @@ internal class AsuraScansParser(context: MangaLoaderContext) :
 				append(filter.author.urlEncoded())
 			}
 
-			append("&sort=")
 			append(
 				when (order) {
 					SortOrder.UPDATED_ASC -> "&order=asc"
-					SortOrder.POPULARITY -> "popular"
-					SortOrder.POPULARITY_ASC -> "popular&order=asc"
-					SortOrder.RATING -> "rating"
-					SortOrder.RATING_ASC -> "rating&order=asc"
-					SortOrder.ALPHABETICAL_DESC -> "name"
-					SortOrder.ALPHABETICAL -> "name&order=asc"
-					SortOrder.NEWEST -> "newest"
-					SortOrder.NEWEST_ASC -> "newest&order=asc"
-					else -> "" // SortOrder.UPDATED
+					SortOrder.POPULARITY -> "&sort=popular"
+					SortOrder.POPULARITY_ASC -> "&sort=popular&order=asc"
+					SortOrder.RATING -> "&sort=rating"
+					SortOrder.RATING_ASC -> "&sort=rating&order=asc"
+					SortOrder.ALPHABETICAL_DESC -> "&sort=name"
+					SortOrder.ALPHABETICAL -> "&sort=name&order=asc"
+					SortOrder.NEWEST -> "&sort=newest"
+					SortOrder.NEWEST_ASC -> "&sort=newest&order=asc"
+					else -> "" // SortOrder.UPDATED is the site default
 				},
 			)
 		}
@@ -137,14 +136,14 @@ internal class AsuraScansParser(context: MangaLoaderContext) :
 				coverUrl = a.selectFirst("img")?.src(),
 				title = card.selectFirst("h3")?.text().orEmpty(),
 				altTitles = emptySet(),
-				rating = a.selectFirst("div > span")?.text()?.toFloatOrNull() ?: RATING_UNKNOWN,
+				rating = a.selectFirst("div > span")?.text()?.toFloatOrNull()?.div(10f) ?: RATING_UNKNOWN,
 				tags = emptySet(),
 				authors = emptySet(),
-				state = when (card.selectLast("span.capitalize")?.text()) {
-					"Ongoing" -> MangaState.ONGOING
-					"Completed" -> MangaState.FINISHED
-					"Hiatus" -> MangaState.PAUSED
-					"Dropped" -> MangaState.ABANDONED
+				state = when (card.selectLast("span.capitalize")?.text()?.lowercase()) {
+					"ongoing" -> MangaState.ONGOING
+					"completed" -> MangaState.FINISHED
+					"hiatus" -> MangaState.PAUSED
+					"dropped" -> MangaState.ABANDONED
 					else -> null
 				},
 				source = source,


### PR DESCRIPTION
## Summary

Fixes three latent list-page bugs on AsuraScans that prevent correct display of ratings, status badges, and pagination:

- **Rating**: list cards were reporting `9.5` instead of `0.95`. The `Manga.rating` contract is `0f..1f`, but the site shows ratings on a 0–10 scale. Now divided by `10f` to normalize, matching the rest of the parser (see `getDetails` which already divides by 10).
- **State**: the site markup uses lowercase text (`"ongoing"`, `"completed"`, `"hiatus"`, `"dropped"`) in `span.capitalize` (which only capitalizes visually via CSS), so the previous `when` branches matching `"Ongoing"` / `"Completed"` / etc. never fired and every card had `state = null`. Lowercased the lookup and branch keys.
- **pageSize**: the browse page returns **20** cards per page, not 30. With `pageSize = 30` the Paginator mapped offsets to the wrong page numbers, causing dropped/duplicated entries on scroll.
- **Sort URL**: cleaned up the sort-query builder so the `&sort=` prefix lives inside each branch. Previously the default `SortOrder.UPDATED` produced a stray `&sort=` with an empty value (which the site ignores, but still — cleaner URL).

## Test plan

- [x] Verified live site (`asurascans.com/browse?page=1`) returns 20 `div.series-card` per page
- [x] Verified rating badge format via `div > span` — site shows e.g. `9.5` (0–10 scale)
- [x] Verified state badge via `span.capitalize` — site emits lowercase text
- [x] Verified all sort permutations (`&sort=popular`, `&sort=rating`, `&sort=name`, `&sort=newest`) return results
- [x] Kept existing selectors for details/chapters/pages (still working on current site)