### PR TITLE
fix(all/mangafire): stop per-related-manga fanout to avoid 429 — fixes #152

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaFireParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaFireParser.kt
@@ -404,45 +404,37 @@ internal abstract class MangaFireParser(
     override suspend fun getRelatedManga(seed: Manga): List<Manga> {
         val document = webClient.httpGet(seed.url.toAbsoluteUrl(domain)).parseHtml()
 
+        // The .m-related section only contains title + URL (no cover / language data).
+        // The previous implementation made a full-page request per related manga to
+        // verify the language and fetch a cover, which fanned out to 16+ extra
+        // requests on popular titles and tripped the site's rate limiter (#152).
+        // We now trust the server's relation list as-is and drop the cover rather
+        // than hitting the site N more times.
+        val seen = HashSet<String>()
         val mangas = document.select("section.m-related a[href*=/manga/]").mapNotNull {
             val url = it.attrAsRelativeUrl("href")
-
-            try {
-                val mangaDocument = webClient
-                    .httpGet(url.toAbsoluteUrl(domain))
-                    .parseHtml()
-
-                val chaptersInManga = mangaDocument.select(".m-list div.tab-content .list-menu .dropdown-item")
-                    .map { i -> i.attr("data-code").lowercase() }
-
-
-                if (!chaptersInManga.contains(siteLang)) {
-                    return@mapNotNull null
-                }
-
-                Manga(
-                    id = generateUid(url),
-                    url = url,
-                    publicUrl = url.toAbsoluteUrl(domain),
-                    title = it.ownText(),
-                    coverUrl = mangaDocument.selectFirstOrThrow("div.manga-detail div.poster img")
-                        .attrAsAbsoluteUrl("src"),
-                    source = source,
-                    altTitles = emptySet(),
-                    largeCoverUrl = null,
-                    authors = emptySet(),
-                    contentRating = null,
-                    rating = RATING_UNKNOWN,
-                    state = null,
-                    tags = emptySet(),
-                )
-            } catch (_: Exception) {
-                null
-            }
+            if (!seen.add(url)) return@mapNotNull null
+            val title = it.ownText().ifBlank { return@mapNotNull null }
+            Manga(
+                id = generateUid(url),
+                url = url,
+                publicUrl = url.toAbsoluteUrl(domain),
+                title = title,
+                coverUrl = null,
+                source = source,
+                altTitles = emptySet(),
+                largeCoverUrl = null,
+                authors = emptySet(),
+                contentRating = null,
+                rating = RATING_UNKNOWN,
+                state = null,
+                tags = emptySet(),
+            )
         }.toMutableList()
 
         document.select(".side-manga:not(:has(.head:contains(trending))) .unit").forEach {
             val url = it.attrAsRelativeUrl("href")
+            if (!seen.add(url)) return@forEach
             mangas.add(
                 Manga(
                     id = generateUid(url),


### PR DESCRIPTION
## Summary

Opening a details page on MangaFire triggers a "too many requests" toast on every title. Root cause: `getRelatedManga` fans out one full `GET /manga/\{slug\}` per entry in the `section.m-related` list — it does this purely to (a) language-verify the related entry and (b) scrape its cover, which aren't in the related-section markup itself.

Popular titles carry 16+ related entries, so opening One Piece made ~20 serial HTTP requests and reliably tripped MangaFire's rate limiter. The title you just clicked also hits rate-limit territory on the very next action.

## Fix

Drop the per-related-manga fetch. Extract title + URL from the `.m-related` markup directly and let `coverUrl = null` for those entries. The existing `.side-manga` block still provides 6 properly-covered "you may also like" suggestions with zero additional fetches. Added a seen-URL dedupe so the two sections don't double-count.

## Tradeoff

Previously, related entries that didn't have a chapter list in the user's language were silently filtered out. After this change, cross-language relateds can appear in the suggestions list. That's a small UX regression but dramatically better than the rate-limited "click a title → fail" loop users are hitting now.

## Test plan

- [x] Details page opens once without 429
- [x] Related section is populated (m-related titles, no covers) + side-manga (with covers)
- [x] Dedupe: a manga listed in both sections only appears once
- [x] Author-fallback path still runs when both lists are empty

Fixes #152
