### PR TITLE
fix(pt/atemporal): mark @Broken - domain offline

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atemporal.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/pt/Atemporal.kt
@@ -1,10 +1,12 @@
 package org.koitharu.kotatsu.parsers.site.madara.pt
 
+import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
+@Broken // atemporal.cloud is offline (connection refused) and no successor domain has surfaced publicly.
 @MangaSourceParser("ATEMPORAL", "Atemporal", "pt")
 internal class Atemporal(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.ATEMPORAL, "atemporal.cloud") {


### PR DESCRIPTION
Part of #166.

`atemporal.cloud` stopped responding (TCP connection refused from multiple regions, no DNS or HTTP/2 response). I searched for a successor: no public replacement domain has been announced, the MangaDex group profile still lists `atemporal.cloud`, Keiyoushi's Tachiyomi source still hardcodes `atemporal.cloud` as of their latest commit, and their Discord doesn't publicly expose a new reader URL.

Rather than leave the parser in a perpetually-failing state for users, this marks it `@Broken` the same way other dead sources have been handled. If/when a successor domain surfaces, the parser can be repointed and (since the old site was actually MangaThemesia as of their last restructure, not Madara as we assume here) rewritten against the correct base.