### PR TITLE
fix(MangaGojo): mark @Broken — mangagojo.com domain is dead

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/MangaGojo.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/MangaGojo.kt
@@ -1,10 +1,12 @@
 package org.koitharu.kotatsu.parsers.site.mangareader.en
 
+import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 
+@Broken // mangagojo.com domain is dead (NXDOMAIN); operators scattered content across iframe-redirect chains (mangagojo.my -> freeonlinek.top -> weebrook.com) with no clean one-to-one replacement.
 @MangaSourceParser("MANGAGOJO", "MangaGojo", "en")
 internal class MangaGojo(context: MangaLoaderContext) :
 	MangaReaderParser(context, MangaParserSource.MANGAGOJO, "mangagojo.com", 30, 20)


### PR DESCRIPTION
`mangagojo.com` no longer resolves (NXDOMAIN). The operators have scattered content across an iframe-redirect chain (`mangagojo.my` → `freeonlinek.top` → `weebrook.com`), and the new landing pages use a different content structure (WordPress `/toon/` / `/toon-genre/` paths rather than MangaReader `/manga/`), so there is no clean one-to-one replacement. Mark the parser `@Broken` rather than pointing it at an unrelated site.

Fixes #197