### PR TITLE
fix(TeamXNovel): load all chapter pages instead of just the first

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ar/TeamXNovel.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ar/TeamXNovel.kt
@@ -176,7 +176,7 @@ internal class TeamXNovel(context: MangaLoaderContext) :
 					coroutineScope {
 						val result = ArrayList(parseChapters(doc))
 						result.ensureCapacity(result.size * maxPageChapter)
-						(2 downTo maxPageChapter).map { i ->
+						(2..maxPageChapter).map { i ->
 							async {
 								loadChapters(mangaUrl, i)
 							}


### PR DESCRIPTION
`(2 downTo maxPageChapter)` is an empty `IntProgression` when `maxPageChapter > 2`, so for any series with 3+ pages of chapters (~201+ chapters at 100/page) only page 1 was ever fetched — which matches the reported symptom of only seeing the most recent ~100 chapters.

Verified against `olympustaff.com/series/eternal-club`: page 1 shows 100 `.chapter-card` entries and a `?page=2` pagination link exists; with the old range these later pages were silently skipped.

Switched to ascending `(2..maxPageChapter)`.

Fixes #199