### PR TITLE
chore: clear already-resolved/out-of-scope/duplicate issues

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KofiScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KofiScans.kt
@@ -4,7 +4,7 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import java.util.*
+import java.util.Locale
 
 @MangaSourceParser("KOFISCANS", "KofiScans", "id")
 internal class KofiScans(context: MangaLoaderContext) :


### PR DESCRIPTION
## Summary

Housekeeping PR to clear out already-resolved, out-of-scope, and duplicate issues so the tracker only reflects actual parser work. Bundles a one-line import cleanup in KofiScans with auto-close directives for issues that need no code changes.

### Already-fixed / superseded (parsers already exist and are live)

- **#14 FlameScans (en)** — site rebranded to flamecomics.xyz; handled by existing `FlameComics` parser (`site/en/FlameComics.kt`).
- **#43 LilyManga (en)** — parser has existed since 2023 at `site/madara/en/LilyManga.kt` (lilymanga.net, `/ys/`, `ys-genre/`).
- **#109 Hipercool (pt)** — parser exists at `site/madara/pt/Hipercool.kt`; hiper.cool verified live.
- **#208 isekaikomik (id)** — already covered by the existing `KofiScans` parser pointed at isekaikomik.com.
- **#237 Hipercool (pt)** — duplicate of #109 (same source, same parser).

### Dead site

- **#30 dangoscan (en)** — domain permanently dead (NXDOMAIN across all variants).

### Out of scope for kotatsu-parsers (not a manga source / wrong repo)

- **#29 megahentai.biz** — hentai *video* streaming site (`<ul class="episodios">`, "Assistir"/"Baixar", `/episodio/{slug}` URLs). Not manga.
- **#34 tiraninha.baby** — serves a 1 KB FingerprintJS redirect placeholder, no manga content at all. Parked/bot-gate domain.
- **#45 Mangaupdates as tracker** — feature request to add a tracker backend. Trackers live in the main Kotatsu app, not this parser library.
- **#82 Update download paused/stopped** — app update/installer bug, not a parser issue.
- **#85 allmanga.to** — the issue explicitly links `allmanga.to/anime` (anime, not manga). Also a React SPA over a private GraphQL API.
- **#144 v2ph.com** — "V2PH HD Beauty Picture Network" adult photo-gallery site (97x "album", 23x "model"); has no chapter/page abstraction that maps to a manga reader.

### Duplicate

- **#231 Kagane** — duplicate of #204 (same source, same link https://kagane.org; #204 was filed first).

### Code change

`KofiScans.kt`: `import java.util.*` → `import java.util.Locale` (only `Locale` is referenced).

### Test plan
- [x] `KofiScans.kt` compiles with narrowed import.
- [x] No behavior change to any parser.

Closes #14
Closes #29
Closes #30
Closes #34
Closes #43
Closes #45
Closes #82
Closes #85
Closes #109
Closes #144
Closes #208
Closes #231
Closes #237