### PR TITLE
fix(Lmtos): unbrook — still a standard Madara site at lmtos.com

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Lmtos.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/Lmtos.kt
@@ -1,14 +1,10 @@
 package org.koitharu.kotatsu.parsers.site.madara.es
 
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-@Broken("Not dead, changed template")
 @MangaSourceParser("LMTOS", "Lmtos", "es")
 internal class Lmtos(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.LMTOS, "lmtos.com") {
-	override val datePattern = "dd/MM"
-}
+	MadaraParser(context, MangaParserSource.LMTOS, "lmtos.com")


### PR DESCRIPTION
## Summary

`lmtos.com` is back up and still running the same WordPress/Madara template (standard `page-item-detail manga` cards at `/manga/`, chapters via `/manga/{slug}/ajax/chapters/`, standard `wp-manga-chapter-img` page lister).

- Remove `@Broken("Not dead, changed template")` — the template never changed.
- Drop stale `datePattern = "dd/MM"` override. Site now renders dates like `abril 13, 2026`, which parses correctly with Madara's default `MMMM d, yyyy` pattern + the parser's default `es` locale.

## Verified
- `GET https://lmtos.com/manga/page/1/?m_orderby=latest` → 19 `.page-item-detail` cards per page.
- `GET https://lmtos.com/page/1/?s=a&post_type=wp-manga` → 37 matching posts.
- `POST https://lmtos.com/manga/{slug}/ajax/chapters/` returns the chapter list HTML.
- `GET https://www.lmtos.com/manga/{slug}/{chapter}/?style=list` → 19 `.wp-manga-chapter-img` page images.

## Test plan
- [ ] Open Lmtos in Kotatsu, verify listings + search populate.
- [ ] Open any series, confirm chapters load and dates render.
- [ ] Open a chapter, confirm images load.
