### PR TITLE
chore: add dependabot config for gradle and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+    # Gradle dependencies (declared in gradle/libs.versions.toml + build.gradle.kts)
+    -   package-ecosystem: "gradle"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+            day: "monday"
+        open-pull-requests-limit: 5
+        labels:
+            - "dependencies"
+        commit-message:
+            prefix: "chore(deps)"
+
+    # GitHub Actions used by workflows in .github/workflows
+    -   package-ecosystem: "github-actions"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+            day: "monday"
+        open-pull-requests-limit: 5
+        labels:
+            - "dependencies"
+            - "github-actions"
+        commit-message:
+            prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so dependency and workflow-action updates surface as PRs instead of going unnoticed.

- **gradle** ecosystem at `/` — picks up `gradle/libs.versions.toml` and direct `build.gradle.kts` declarations. Covers OkHttp, Okio, Jsoup, Kotlin coroutines, KSP, JUnit, QuickJS, androidx.collection, kotlin-stdlib.
- **github-actions** ecosystem at `/` — scans the 5 workflows in `.github/workflows/`. Matters because the repo pins actions by SHA, and SHA-pinned actions never get free security updates otherwise.

Tuning:

- Weekly schedule, Mondays — batches updates instead of drip-feeding notifications.
- `open-pull-requests-limit: 5` per ecosystem to prevent flooding if several deps release at once.
- Commit prefix `chore(deps)` matches the existing commit style visible in recent history.
- Labels `dependencies` / `github-actions` for easy filtering / triage.

No code or build change — pure config.

## Test plan

- [x] YAML syntax valid (parsed clean locally).
- [x] Ecosystems, directories, and labels match what's actually in the repo (`gradle/libs.versions.toml` present, 5 action workflows present).
- [x] SHA-pinned actions in existing workflows (e.g. `actions/checkout@0c366fd6...`) will be updated by Dependabot's github-actions ecosystem.
- [ ] After merge, Insights → Dependency graph → Dependabot shows both ecosystems as enabled.