### PR TITLE
chore: add CodeQL security-and-quality analysis for Kotlin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+on:
+    push:
+        branches: [ "master" ]
+    pull_request:
+        branches: [ "master" ]
+        paths:
+            - 'src/**'
+            - 'build.gradle.kts'
+            - 'gradle/libs.versions.toml'
+            - '.github/workflows/codeql.yml'
+    schedule:
+        -   cron: '17 4 * * 1'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        permissions:
+            security-events: write
+            actions: read
+            contents: read
+
+        strategy:
+            fail-fast: false
+            matrix:
+                language: [ 'java-kotlin' ]
+
+        steps:
+            -   name: Checkout repository 🌏
+                uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6.0.2
+
+            -   name: Set up Java environment 🔧
+                uses: actions/setup-java@fe779bf55ef683c9413269276a7588bb9cedf07a # v5.2.0
+                with:
+                    java-version: '11'
+                    distribution: 'temurin'
+
+            -   name: Set up Gradle environment 📦
+                uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+                with:
+                    gradle-version: '9.3.1'
+
+            -   name: Initialize CodeQL 🔍
+                uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+                with:
+                    languages: ${{ matrix.language }}
+                    queries: security-and-quality
+
+            -   name: Build with Gradle 🚀
+                run: ./gradlew compileKotlin --no-daemon
+
+            -   name: Perform CodeQL Analysis 🔬
+                uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+                with:
+                    category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds GitHub's CodeQL static analysis for the Kotlin sources. Pairs with #281 (SECURITY.md) to give the Security tab real signal instead of an empty shelf.

- Single matrix entry `java-kotlin` — CodeQL's combined Kotlin/Java language pack; this repo's a Kotlin/JVM library so that's the right target.
- `security-and-quality` query pack — picks up the standard security checks plus maintainability lints. Drop to `security-extended` or `security-only` if the quality queries turn out to be noisy.
- Triggers: push to master, PRs that touch `src/**` or the build, weekly cron, manual dispatch. Cron picked so the job doesn't stack on top of `test-parsers.yml` on PRs.
- Style matches `test-parsers.yml`: 4-space indent, emoji step names, SHA-pinned actions with `# v-tag` comments, same Java 11 / Gradle 9.3.1 toolchain, same permissions discipline (default read-only with explicit `security-events: write` on the analyze job only).
- `timeout-minutes: 45` — CodeQL builds on a cold Gradle cache can run long.

## Test plan

- [x] YAML lint clean.
- [x] Action SHAs pinned and matched to the most recent stable tags (`actions/checkout@0c366fd6...` v6.0.2, `setup-java@fe779bf5...` v5.2.0, `gradle/actions/setup-gradle@07231958...` v5.0.2, `codeql-action@4e828ff8...` v3.29.4).
- [x] Compile command `./gradlew compileKotlin` matches what `test-parsers.yml` already runs; CodeQL just watches the build.
- [ ] First run on merge finishes green (or, if queries fire, findings are reviewable in Security → Code scanning).
- [ ] Dependabot PR-er from #(companion dependabot PR) will keep the 4 action SHAs fresh.