### PR TITLE
chore(issue-templates): align auto-labels with proposed scheme (refs #286)

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -1,6 +1,6 @@
 name: ⭐ Feature request
 description: Suggest a feature to improve a source
-labels: [ feature request ]
+labels: [ enhancement ]
 body:
 
     -   type: textarea

--- a/.github/ISSUE_TEMPLATE/request_removal.yml
+++ b/.github/ISSUE_TEMPLATE/request_removal.yml
@@ -1,6 +1,6 @@
 name: 🗑 Source removal request
 description: Scanlators can request their site to be removed
-labels: [ source removal ]
+labels: [ "source: removal" ]
 body:
 
     -   type: input

--- a/.github/ISSUE_TEMPLATE/request_source.yml
+++ b/.github/ISSUE_TEMPLATE/request_source.yml
@@ -1,6 +1,6 @@
 name: 🌐 Source request
 description: Suggest a new source for Kotatsu
-labels: [ source request ]
+labels: [ "source: request" ]
 body:
 
     -   type: markdown


### PR DESCRIPTION
## Summary

Follow-up PR I volunteered in #286.

The three non-bug issue forms reference labels that **don't exist** in the repo (the current label set is the 9 GitHub defaults only), so GitHub silently drops them on submit and new issues land unlabeled. This PR fixes that.

| Form | Before | After |
|---|---|---|
| `request_feature.yml` | `feature request` *(missing)* | `enhancement` *(exists, default)* |
| `request_removal.yml` | `source removal` *(missing)* | `source: removal` |
| `request_source.yml`  | `source request` *(missing)*  | `source: request` |

`report_issue.yml` already uses `bug` and is left untouched.

## Why this is safe to merge standalone

The two `source:`-prefixed labels don't exist yet. Per the GitHub issue-form schema docs, unknown label names in a `labels:` block are silently skipped on submit — they don't cause the form to fail. So:

- **Today** this PR is equivalent to the current state for the two removal/source forms (both broken).
- **`request_feature.yml` starts working immediately** because `enhancement` is a GitHub default that already exists.
- **The moment `source: request` and `source: removal` are created** per the scheme in #286, the remaining two forms start auto-labelling automatically, no follow-up PR needed.

## Test plan

- [x] Diff is 3 one-line changes, nothing else touched
- [x] Confirmed existing labels on repo (9 defaults) — the 3 old labels never existed
- [x] YAML is valid (quoted `"source: ..."` because of the colon)
- [ ] Maintainer creates the remaining labels from #286 whenever they're ready

Refs #286