### PR TITLE
chore(ci): SHA-pin remaining third-party actions

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -64,7 +64,7 @@ jobs:
 
             -   name: Create Pull Request 🚀
                 if: steps.summary_check.outputs.changed == 'true'
-                uses: peter-evans/create-pull-request@v8.1.0
+                uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
                 with:
                     token: ${{ secrets.GITHUB_TOKEN }}
                     branch: auto/update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
                     gradle-version: '9.3.1'
 
             -   name: Setup Android SDK 🚀
-                uses: android-actions/setup-android@v3
+                uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
             -   name: Run assemble tasks 🚀
                 run: ./gradlew assemble --rerun-tasks
@@ -54,7 +54,7 @@ jobs:
                 continue-on-error: true
 
             -   name: Upload artifacts 🌐
-                uses: softprops/action-gh-release@v2
+                uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
                 with:
                     repository: mochi-plugins/repository
                     tag_name: ${{ steps.meta.outputs.sha_short }}


### PR DESCRIPTION
## Summary

Completes the SHA-pinning pattern already used in the rest of `.github/workflows/`. Three third-party actions were still on floating tags:

| File | Action | Before | After |
|---|---|---|---|
| `publish.yml` | `android-actions/setup-android` | `@v3` | `@9fc6c4e…` *(v3.2.2)* |
| `publish.yml` | `softprops/action-gh-release` | `@v2` | `@3bb1273…` *(v2.6.2)* |
| `create-pr.yml` | `peter-evans/create-pull-request` | `@v8.1.0` | `@c0f553f…` *(v8.1.0)* |

## Why

The first-party GitHub actions in this repo (`actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`) are all already pinned by SHA with a `# vX.Y.Z` comment. This PR applies the same treatment to the three remaining third-party actions so the workflows match their own house style and are no longer exposed to floating-tag tampering.

Background on why this matters for CI supply-chain hygiene: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions — GitHub's own recommendation is to pin third-party actions to a full-length commit SHA.

## SHAs verified against upstream

Each SHA matches the tip of the tagged release at the time of this PR (verified via `GET /repos/:owner/:repo/tags`).

## Behaviour change

**None** — `v3`, `v2`, and `v8.1.0` tags currently point at these same SHAs, so CI behaviour is identical. Future action maintainers can no longer silently re-point the tag at a new commit.

## Getting updates

#282 adds Dependabot for `github-actions`, which will automatically open PRs bumping these pins when a new upstream release ships. (Without Dependabot, pinned SHAs never see updates.) Stacks cleanly on top of that PR.