### PR TITLE
chore(issue-templates): convert source-request language field to dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_source.yml
+++ b/.github/ISSUE_TEMPLATE/request_source.yml
@@ -24,12 +24,30 @@ body:
         validations:
             required: true
 
-    -   type: input
+    -   type: dropdown
         id: language
         attributes:
             label: Language
-            placeholder: |
-                Example: "English"
+            description: Primary language the source publishes in. Pick "Other" and specify in the details box if your language isn't listed.
+            options:
+                - English
+                - Arabic
+                - Chinese
+                - French
+                - German
+                - Indonesian
+                - Italian
+                - Japanese
+                - Korean
+                - Portuguese (Brazil)
+                - Portuguese (Portugal)
+                - Russian
+                - Spanish
+                - Thai
+                - Turkish
+                - Vietnamese
+                - Multi (multiple languages on one site)
+                - Other (specify in the details box below)
         validations:
             required: true
 


### PR DESCRIPTION
## Summary

Converts the `Language` field on `request_source.yml` from a free-text `input` into a `dropdown` with a curated list of common languages + "Other".

## Why

The pt-BR cluster in the current backlog (11 open source requests per the triage in #286) shows the existing free-text field produces inconsistent values — e.g. `pt-BR`, `Portuguese`, `Brazilian Portuguese`, `brasileiro` all land on unrelated issues. A dropdown:

1. **Normalises language values** so triage / reporting can trivially group requests (helpful for prioritising batch-add work on the dominant language bucket).
2. **Sets expectations for the reporter** — they can see at a glance which languages the project already targets.
3. **Doesn't lock anyone out** — the final "Other (specify in the details box below)" option keeps the door open for languages not on the list.

## Option list

Based on the current source tree's top-level directories under `src/main/kotlin/org/koitharu/kotatsu/parsers/site/`, plus `multi` and `all` as already-used values. Reasonable starter set — open to adding / reordering if maintainers want different language priorities.

```
English, Arabic, Chinese, French, German, Indonesian, Italian, Japanese,
Korean, Portuguese (Brazil), Portuguese (Portugal), Russian, Spanish,
Thai, Turkish, Vietnamese, Multi, Other
```

## Scope

- Only touches `request_source.yml` — the other three issue forms don't have a Language field.
- 1 file changed, 1 field replaced. No behavioural change beyond the input shape.

Refs #286