### PR TITLE
fix(ci): bump runner Java to 17 for Gradle 9 and force CodeQL task re-run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
             -   name: Set up Java environment 🔧
                 uses: actions/setup-java@b622de1dfa918ecc0ab28f40cd42e3c3752cd6c5 # v5.2.0
                 with:
-                    java-version: '11'
+                    java-version: '17'
                     distribution: 'temurin'
 
             -   name: Set up Gradle environment 📦
@@ -54,7 +54,7 @@ jobs:
                     queries: security-and-quality
 
             -   name: Build with Gradle 🚀
-                run: ./gradlew compileKotlin --no-daemon
+                run: ./gradlew compileKotlin --no-daemon --rerun-tasks --no-build-cache
 
             -   name: Perform CodeQL Analysis 🔬
                 uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -30,8 +30,8 @@ jobs:
             -   name: Set up Java environment 🔧
                 uses: actions/setup-java@b622de1dfa918ecc0ab28f40cd42e3c3752cd6c5 # v5.2.0
                 with:
-                    # Should check with the lowest version that parsers library supports, no cache
-                    java-version: '11'
+                    # Gradle 9+ requires JVM 17 to run; compile target remains JVM 11 via jvmToolchain(11)
+                    java-version: '17'
                     distribution: 'temurin'
 
             -   name: Set up Gradle environment 📦

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Set up Java enviroment 🔧
                 uses: actions/setup-java@b622de1dfa918ecc0ab28f40cd42e3c3752cd6c5 # v5.2.0
                 with:
-                    java-version: '11'
+                    java-version: '17'
                     distribution: 'temurin'
 
             -   name: Set up Gradle enviroment 📦

--- a/.github/workflows/test-parsers.yml
+++ b/.github/workflows/test-parsers.yml
@@ -19,7 +19,7 @@ jobs:
             -   name: Set up Java enviroment 🔧
                 uses: actions/setup-java@b622de1dfa918ecc0ab28f40cd42e3c3752cd6c5 # v5.2.0
                 with:
-                    java-version: '11'
+                    java-version: '17'
                     distribution: 'temurin'
 
             -   name: Set up Gradle enviroment 📦

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,8 +27,8 @@ jobs:
             -   name: Set up Java environment 🔧
                 uses: actions/setup-java@b622de1dfa918ecc0ab28f40cd42e3c3752cd6c5 # v5.2.0
                 with:
-                    # Should check with the lowest version that parsers library supports, no cache
-                    java-version: '11'
+                    # Gradle 9+ requires JVM 17 to run; compile target remains JVM 11 via jvmToolchain(11)
+                    java-version: '17'
                     distribution: 'temurin'
 
             -   name: Set up Gradle environment 📦


### PR DESCRIPTION
## What

Two small CI fixes that together restore CodeQL on master and quiet Gradle's runtime-version warnings.

### 1. Bump Actions runner Java to 17 across the board

`build.gradle.kts` pins the compile target to JVM 11 via `jvmToolchain(11)`, so this does **not** change what we compile — we still publish a JVM 11 bytecode artifact. It only bumps the JDK that runs Gradle itself.

Affected workflows (all moved from `java-version: '11'` → `'17'`):
- `.github/workflows/codeql.yml`
- `.github/workflows/create-pr.yml`
- `.github/workflows/test-branch.yml`
- `.github/workflows/test-parsers.yml`
- `.github/workflows/update.yml`

`publish.yml` was already on `'17'`, no change.

**Why:** Gradle 9.3.1 (landed in #302's dependency context and already on master) requires JVM 17+ to *run the daemon*. Current runs emit:

```
Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 11.
```

Kotlin's `jvmToolchain(11)` auto-provisions JDK 11 for the compile target regardless of the runner JDK, so the published artifact stays on JVM 11 — this is only about the tool runtime.

### 2. Force CodeQL to see live source

In `codeql.yml` only, change the Gradle build step from:

```yaml
run: ./gradlew compileKotlin --no-daemon
```

to:

```yaml
run: ./gradlew compileKotlin --no-daemon --rerun-tasks --no-build-cache
```

**Why:** CodeQL's Kotlin/Java tracer works by observing live `javac`/`kotlinc` invocations. When Gradle's build cache restores `compileKotlin` and `compileJava` as `FROM-CACHE`, the compiler never runs — so the CodeQL database ends up empty and analysis fails with:

```
CodeQL detected code written in the following languages: Java/Kotlin, but could not process any of it.
No source code was seen during the build.
```

(Reproduced on run [`24628597827`](https://github.com/YakaTeam/kotatsu-parsers/actions/runs/24628597827) — compileKotlin/compileJava/compileTestKotlin/compileTestJava all `FROM-CACHE`, then `exit 32` from `analyze/codeql-runner/finalize`.)

`--rerun-tasks --no-build-cache` forces every compile task to actually execute on every CodeQL run, making sources visible to the tracer. Slightly slower for this one workflow; unchanged for every other workflow (which still benefit from caching).

## Validated on fork

Ran the same branch as a PR on my fork first — CodeQL went from red on master to ✅ success in 4m34s. Job: <https://github.com/AgentKush/kotatsu-parsers/actions/runs/24628859947>.

## Why one PR

Both changes are necessary for CodeQL to pass on master right now:
- Without (1), the runner logs a warning and Gradle 9 complains about JVM 11.
- Without (2), the build is cached and CodeQL sees no source.

Splitting them would leave a broken intermediate state on master.
