### PR TITLE
chore(ci): bump github/codeql-action from v3.29.4 to v4.35.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
                     gradle-version: '9.3.1'
 
             -   name: Initialize CodeQL 🔍
-                uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+                uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
                 with:
                     languages: ${{ matrix.language }}
                     queries: security-and-quality
@@ -57,6 +57,6 @@ jobs:
                 run: ./gradlew compileKotlin --no-daemon --rerun-tasks --no-build-cache
 
             -   name: Perform CodeQL Analysis 🔬
-                uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.4
+                uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
                 with:
                     category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Bump the last remaining Node.js 20 action in `.github/workflows/codeql.yml`:

- `github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8` (v3.29.4, node20)
   → `@95e58e9a2cdfd71adc6e0353d5c52f41a045d225` (v4.35.2, node24)
- `github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8` (v3.29.4, node20)
   → `@95e58e9a2cdfd71adc6e0353d5c52f41a045d225` (v4.35.2, node24)

Both pinned SHAs resolve to `runs.using: node24` in their respective `action.yml`. v4 was released by upstream specifically for the June 2026 Node 24 forced migration — no configuration changes are required for Kotlin analysis, and the `languages` / `queries` / `category` inputs are unchanged between v3 and v4.

## Why

This is the last outstanding action on the Node 20 runtime after the earlier Dependabot bumps landed `android-actions/setup-android` → v4.0.1, `softprops/action-gh-release` → v3.0.0, and `actions/stale` → v10.2.0. Closes the deprecation audit tracked in #293.

## Validated on fork

Fork PR CI ran both CodeQL (v4.35.2) and ktlint — both green:
- CodeQL v4 analysis succeeded end-to-end against the Kotlin codebase
- No v3→v4 breaking behavior surfaced for our configuration

Fixes #293
