### PR TITLE
chore(deps): ignore gradle-wrapper bumps and gradle semver-major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,16 @@ updates:
             - "dependencies"
         commit-message:
             prefix: "chore(deps)"
+        ignore:
+            # Dependabot serialises the gradle-wrapper jar as Base64 text, producing
+            # a wrapper that fails with "Invalid or corrupt jarfile" (see PR #302).
+            # Wrapper bumps must be done manually via `./gradlew wrapper --gradle-version X`.
+            -   dependency-name: "gradle"
+            # Major-version bumps for Kotlin / KSP / JUnit / etc. need coordinated testing
+            # (Kotlin+KSP must move together, JUnit 6 forces JVM 17, etc.). Keep them
+            # out of the auto-PR queue; open them manually when we're ready to validate.
+            -   dependency-name: "*"
+                update-types: [ "version-update:semver-major" ]
 
     # GitHub Actions used by workflows in .github/workflows
     -   package-ecosystem: "github-actions"


### PR DESCRIPTION
### Why

Two classes of Dependabot gradle PRs keep landing in a state that can't be merged:

1. **`gradle-wrapper` bumps** — Dependabot commits `gradle/wrapper/gradle-wrapper.jar` as **Base64-encoded text** instead of a binary jar, so the wrapper fails with `Invalid or corrupt jarfile`. #302 was the reproducer — decoded bytes matched the real Gradle 9.4.1 wrapper, but the file as committed could not run. `@dependabot recreate` did not produce a correct jar. The `buildSrc/` copy of the wrapper in the same PR was fine, so it's specifically the root wrapper that trips the bug.

2. **Gradle semver-major bumps** (Kotlin, KSP, JUnit) — these need coordinated testing (Kotlin + KSP must ship together, JUnit 6 forces JVM 17 compile target, etc.) and shouldn't regenerate weekly as auto-PRs. #294 / #300 / #303 were all closed for this reason.

### What this PR does

Adds two `ignore` entries under the existing `gradle` update block:

* `dependency-name: "gradle"` → stops `gradle-wrapper` PRs. Wrapper bumps will be done manually via `./gradlew wrapper --gradle-version X`.
* `dependency-name: "*"` with `update-types: ["version-update:semver-major"]` → stops gradle-ecosystem major bumps. Open them manually when there's time to validate.

### What this PR does NOT change

* **Library patch/minor bumps** (okio, coroutines, jsoup, etc.) still flow through Dependabot.
* **GitHub Actions bumps are untouched** — the Node.js 20 → 24 deprecation PRs will continue to come through that ecosystem block as normal.

Refs: #302, #294, #300, #303.