### PR TITLE
chore(deps): fix gradle-wrapper ignore name in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,9 @@ updates:
             prefix: "chore(deps)"
         ignore:
             # Dependabot serialises the gradle-wrapper jar as Base64 text, producing
-            # a wrapper that fails with "Invalid or corrupt jarfile" (see PR #302).
+            # a wrapper that fails with "Invalid or corrupt jarfile" (see PRs #302, #309).
             # Wrapper bumps must be done manually via `./gradlew wrapper --gradle-version X`.
-            -   dependency-name: "gradle"
+            -   dependency-name: "gradle-wrapper"
             # Major-version bumps for Kotlin / KSP / JUnit / etc. need coordinated testing
             # (Kotlin+KSP must move together, JUnit 6 forces JVM 17, etc.). Keep them
             # out of the auto-PR queue; open them manually when we're ready to validate.
@@ -36,3 +36,4 @@ updates:
             - "github-actions"
         commit-message:
             prefix: "chore(deps)"
+


### PR DESCRIPTION
Follow-up to #307. The ignore rule I added used `dependency-name: "gradle"` to block the broken wrapper bumps, but Dependabot's actual dependency-name for the Gradle wrapper is `gradle-wrapper` — confirmed by #309 (`chore(deps): bump gradle-wrapper from 8.14.3 to 8.14.4`) landing anyway with the same Base64-encoded-jar corruption as #302.

Rename the ignore entry so the rule actually matches, and close #309 alongside this merge.

Fixes #309.