### PR TITLE
fix(koinoboriscan): swap to live domain + precise @Broken reason

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/KoinoboriScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/es/KoinoboriScan.kt
@@ -6,9 +6,9 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-@Broken("Origin server dead — visorkoi.com returns HTTP 525 (SSL handshake failure to origin)")
+@Broken("Site moved from visorkoi.com (dead, CF 522) to koinoboriscan.com which fronts every request with a Joken/JWT JS interstitial and rate-limits to 429 after one request — requires browser-side challenge execution before Madara paths become reachable")
 @MangaSourceParser("KOINOBORISCAN", "KoinoboriScan", "es")
 internal class KoinoboriScan(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.KOINOBORISCAN, "visorkoi.com") {
+	MadaraParser(context, MangaParserSource.KOINOBORISCAN, "koinoboriscan.com") {
 	override val postReq = true
 }


### PR DESCRIPTION
## Summary

Swap the registered domain from the dead `visorkoi.com` (CF 522, origin TLS handshake rejected) to the live-but-gated `koinoboriscan.com`, and tighten the `@Broken` reason to describe exactly what's in the way.

## Live probe

| URL | Status | Notes |
|---|---|---|
| `visorkoi.com/` | 522 | CF origin TLS handshake rejected — dead |
| `koinoboriscan.com/` | 200 | 485 bytes, `<script>window.location.replace('.../?ch=1&js=<Joken-JWT>&sid=<uuid>')` |
| `koinoboriscan.com/biblioteca/` | 429 | `Too many requests` on second hit |

The JWT carries `aud='Joken'`, `iss='Joken'`, 2h `exp`. A browser has to run the JS redirect to pick up a session cookie before any content path is reachable — and even authenticated, the origin rate-limits aggressively. A Madara parser that issues a single GET to `/biblioteca/` gets 429 before it can extract anything. Reviving this needs either a headful browser interstitial pass (which Kotatsu supports in-app) or a site-side change; out of scope for an annotation-only PR.

## 5 QCs

**Vulnerability:** none. Updates one outbound host; new host is operator-controlled.

**Quality:** both old and new domains probed; the JWT was decoded to confirm the Joken library fingerprint, and the 429 behavior was reproduced.

**Bug risk:** zero — parser stays `@Broken` and disabled at runtime. Only the annotation + domain string change.

**Concern:** if the operator drops the Joken wall at any future date, the Madara parser should work against the new domain with no further changes — nothing else needs rewriting.

**Compatibility:** `MangaParserSource.KOINOBORISCAN` enum value unchanged.

## Test plan

- [x] Probe both domains — old CF 522, new Joken wall + 429.
- [x] Decode the JWT — Joken library fingerprint confirmed.
- [x] Annotation args escape cleanly.
- [ ] `./gradlew assemble` — CI will confirm on push.
