### PR TITLE
fix(komiklokal): repair parser on komikmu.top

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLokalParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikLokalParser.kt
@@ -2,15 +2,13 @@ package org.koitharu.kotatsu.parsers.site.mangareader.id
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.ContentType
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import org.koitharu.kotatsu.parsers.Broken
-import java.util.*
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
-@MangaSourceParser("KOMIKLOKAL", "KomikLokal", "id")
+@MangaSourceParser("KOMIKLOKAL", "KomikLokal", "id", ContentType.HENTAI)
 internal class KomikLokalParser(context: MangaLoaderContext) :
 	MangaReaderParser(context, MangaParserSource.KOMIKLOKAL, "komikmu.top", pageSize = 20, searchPageSize = 10) {
-	override val datePattern = "MMM d, yyyy"
-	override val sourceLocale: Locale = Locale.ENGLISH
+	override val listUrl = "/komik"
+	override val datePattern = "dd/MM/yyyy"
 }


### PR DESCRIPTION
## Summary

Un-`@Broken` the KomikLokal parser (`komikmu.top`). Live probes confirm every browse/detail/reader path works against the base `MangaReaderParser`, and every `filterCapabilities` flag inherited from the base parser is honoured server-side. The only real changes needed to revive the parser are a `listUrl` override (catalog lives at `/komik`, not `/manga`), a date-format fix, and a content-type reclassification to match the catalog.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET komikmu.top/komik/` | 200, 20 `<div class="bsx">` entries with working `https://komikmu.top/komik/<slug>/` hrefs |
| `GET komikmu.top/komik/12-years-apart/` | 200, `#chapterlist` with 40 `<li data-num="…">` entries, chapter anchors resolve |
| `GET komikmu.top/12-years-apart-chapter-40-end/` | 200, `#readerarea` + `ts_reader.run({…})` with `sources[0].images` = 8 pages served from `warungkomikcdn.icu` |

No CF challenge, no login gate, no Joken/Anubis/Sedo interstitial. Base `MangaReaderParser` selectors (`selectMangaList = ".postbody .listupd .bs .bsx"`, `selectChapter = "#chapterlist > ul > li"`, `selectTestScript = "script:containsData(ts_reader)"`) match the live DOM without modification.

## What the live probe showed — filter flags

Every inherited `filterCapabilities` flag was probed against the live site. All survived.

| Flag | Live probe | Kept? |
|---|---|---|
| `isSearchSupported` (default `true`) | `?s=naruto` → 6 title-matching hits, `?s=sword` → 1, `?s=romance` → 8, `?s=zzznotexist` → 0. Server honours `s=`. | ✓ **keep** |
| `isMultipleTagsSupported` (default `true`) | `genre[]=1778` (Action) → 4 hits, `genre[]=1743` (Adventure) → 2 hits, `genre[]=1778&genre[]=1743` → 0 hits. AND semantics: result is subset of both and neither (no overlap). Last-wins would return the Adventure-only set; OR would return 4+2=6. Only AND fits. | ✓ **keep** |
| `isTagsExclusionSupported` (default `true`) | `genre[]=-1778` returns 20 hits with **0/4** overlap against the Action-only set. Exclusion actually excludes. | ✓ **keep** |

Additionally probed even though they're URL-builder params, not capability flags:

| Param | Live probe |
|---|---|
| `order=latest`/`update`/`popular`/`title`/`titlereverse` | Five distinct top-3 sets; each ordering is honoured. |
| `type=manga`/`manhwa`/`manhua`/`comic`/`novel` | Five distinct result sets with non-trivial differences (manhua → 3 hits, novel → 3 hits, manhwa → 20 hits). |
| `status=ongoing`/`completed`/`hiatus` | Three distinct result sets. |

So the full URL builder (`listUrl + ?s=…&genre[]=…&order=…&page=…&type=…&status=…`) is safe to leave at its inherited behavior — every arm is real.

## What changes

`KomikLokalParser.kt` only, single commit:

- Drop `@Broken` annotation — parser is functional for browse/detail/reader.
- Drop the stale `Broken` import and the stale `java.util.*` import (only ever used for the now-unnecessary `Locale.ENGLISH` override).
- Drop the `sourceLocale = Locale.ENGLISH` override — the catalog is Indonesian, matching the declared locale already; the old override was copy-paste crust.
- Override `listUrl = "/komik"` — catalog lives at `/komik/`, not at the inherited default.
- Fix `datePattern` typo: `"MMM d, yyyy"` → `"dd/MM/yyyy"` (live chapter dates are numeric: `28/10/2024`, `24/11/2024`, `14/07/2024`).
- Add `ContentType.HENTAI` to `@MangaSourceParser` — listing titles on probe day are overwhelmingly adult Indonesian doujin (`ahegao`/`18+` genres return 20 hits, catalog includes `15-menit-yang-sangat-nikmat`, `3-vs-1-volleyball-match`, `rela-babak-belur-untuk-melindungi-kemaluan-kakak-kelasku`, etc). Classifying as generic manga misleads the user/UI.

No other files changed. `MangaParserSource.KOMIKLOKAL` enum is preserved (KSP re-generated from the unchanged annotation name).

## 5 QCs

**Vulnerability:** none. This is a boolean flip (`@Broken`) plus a pre-existing override (`listUrl`) plus a date format correction. No new endpoints hit, no new user input surfaces, no new network calls. Removing the stale `sourceLocale = Locale.ENGLISH` override actually *improves* correctness — chapter dates will now parse in the declared site locale (`id`) instead of an artificial English locale that was silently wrong for a `dd/MM/yyyy`-formatted Indonesian date.

**Quality:** evidence-driven. Every flag inherited from `MangaReaderParser` was probed against the live server with multiple variants: search with 4 different queries including a nonsense string; multi-tag tested with disambiguating AND-vs-OR-vs-last-wins signatures; exclusion tested against a known-positive set (Action genre) with 0/4 overlap confirmation. Date pattern verified against three live chapter dates. Content-type reclassification anchored to the literal listing titles.

**Bug risk:** low. Every behavior touched is verified working on the live server at commit time. Nothing in the set of changes narrows capability — only `listUrl` actually alters the runtime URL shape, and `/komik/` is confirmed to return the 20-entry listing with the correct selectors matching. Date fix upgrades a silently-broken parser-date field to a working one.

**Concern:** one — the `warungkomikcdn.icu` page host is a domain unrelated to `komikmu.top`. If this CDN is rotated, reader images may break. Out of scope for this PR: the `selectPage`/`ts_reader` extraction path is shared across all MangaReader sites and will follow whatever host the `sources[].images` array specifies at runtime, so no parser-level change is needed.

**Compatibility:** zero impact on other parsers. The base `MangaReaderParser` class is untouched. `MangaParserSource.KOMIKLOKAL` enum value is preserved. No public API changed. Build/KSP/CI untouched.

## Test plan

- [x] Live probe `/komik/` → 20 `<div class="bsx">` items with proper `/komik/<slug>/` hrefs.
- [x] Live probe detail page (`12-years-apart`) → `#chapterlist` with 40 `<li>` entries carrying `data-num`.
- [x] Live probe chapter page → `#readerarea` present with `ts_reader.run({…})` JSON → `sources[0].images` = 8 pages.
- [x] Live probe every inherited `filterCapabilities` flag — all 3 kept with evidence.
- [x] Live probe `order=` / `type=` / `status=` / `page=` — all verified working.
- [x] Verify date pattern against live chapter dates (4-digit year, `dd/MM/yyyy` format).
- [x] Grep tree for any external consumer of the old `Broken`-annotated `KomikLokal` class — none.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
