### PR TITLE
fix(rizzcomic): repair parser and correct multi-tag flag

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/RizzComic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/RizzComic.kt
@@ -11,10 +11,8 @@ import org.koitharu.kotatsu.parsers.util.json.getFloatOrDefault
 import org.koitharu.kotatsu.parsers.util.json.getStringOrNull
 import org.koitharu.kotatsu.parsers.util.json.mapJSON
 import org.koitharu.kotatsu.parsers.util.suspendlazy.suspendLazy
-import org.koitharu.kotatsu.parsers.Broken
 import java.util.*
 
-@Broken("Blocked by Cloudflare challenge")
 @MangaSourceParser("RIZZCOMIC", "RizzComic", "en")
 internal class RizzComic(context: MangaLoaderContext) :
 	MangaReaderParser(context, MangaParserSource.RIZZCOMIC, "rizzfables.com", pageSize = 50, searchPageSize = 20) {
@@ -31,7 +29,7 @@ internal class RizzComic(context: MangaLoaderContext) :
 
 	override val filterCapabilities: MangaListFilterCapabilities
 		get() = super.filterCapabilities.copy(
-			isMultipleTagsSupported = true,
+			isMultipleTagsSupported = false,
 			isSearchSupported = true,
 			isTagsExclusionSupported = false,
 		)
@@ -78,14 +76,12 @@ internal class RizzComic(context: MangaLoaderContext) :
 			else -> {
 				val state = filter.states.oneOrThrowIfMany()?.toPayloadValue() ?: "all"
 
-				val genres = filter.tags.map { it.key }
-
 				val form = ArrayMap<String, String>()
 				form["StatusValue"] = state
 				form["TypeValue"] = "all"
 				form["OrderValue"] = order.toPayloadValue()
 
-				genres.forEach { genre ->
+				filter.tags.oneOrThrowIfMany()?.key?.let { genre ->
 					form["genres_checked[]"] = genre
 				}
 				form


### PR DESCRIPTION
## Summary

Un-`@Broken` the RizzComic parser (`rizzfables.com`). The `@Broken("Blocked by Cloudflare challenge")` annotation no longer reflects reality — no CF challenge is served on any of the browse/filter/detail/reader paths, and the site's POST-backed `filter_series` / `live_search` endpoints return proper JSON. The catch is that the server-side multi-tag filter is **OR, not AND** — the old parser advertised `isMultipleTagsSupported = true` which was a lie, and also silently dropped all-but-the-last tag in its URL builder (`ArrayMap` overwrites on repeated keys). Both bugs fixed in a single commit.

## What the live probe showed — paths

| Endpoint | Method | Result |
|---|---|---|
| `GET rizzfables.com/series` | GET | 200, 88 `<div class="bsx">` entries in `.listupd`; no CF challenge banner in the markup |
| `POST rizzfables.com/Index/filter_series` | form POST | 200, JSON array of 87 series with full metadata (id/title/image_url/rating/description/status/type/genre_id/author/long_description) |
| `POST rizzfables.com/Index/live_search` | form POST | 200, JSON array with titles matching the `search_value` (tested `solo` → 1 hit, nonsense → 0) |
| `GET rizzfables.com/series/r2311170-a-bad-person` | GET | 200, `#chapterlist` with 129 `<li data-num="…">` entries, chapter anchors resolve |
| `GET rizzfables.com/chapter/r2311170-a-bad-person-chapter-127` | GET | 200, `#readerarea` with 19 `<img>` tags pointing at `cdn.rizzfables.com/wp-content/uploads/…` |

Base `MangaReaderParser.getPages` uses `selectPage = "div#readerarea img"` when `ts_reader.run(...)` is absent — that branch is exactly what this site now serves. No parser-level reader change needed.

## What the live probe showed — filter flags

Every `filterCapabilities` flag advertised by the parser was probed against the live POST endpoint. The `isMultipleTagsSupported = true` claim turned out to be a lie that needed correcting — the parser was also silently *dropping* all but the last tag in its URL builder (an `ArrayMap` is repeat-key last-wins), so in effect `isMultipleTagsSupported` was already broken both client-side (last-wins) and server-side (OR).

| Flag | Live probe | Kept? |
|---|---|---|
| `isSearchSupported` | `search_value=solo` → 1 hit ("Solo Farming In The Tower"); `search_value=zzznotexistabc` → 0 hits. | ✓ **keep** |
| `isMultipleTagsSupported` | Action(78) + Adaptation(4), where intersection = 4 items and union = 78 items: POST returns 78. Probe reversed Adaptation(4) + Action(78) also returns 78. Only OR (union) fits — intersection/AND would be 4, last-wins would give 4 in one ordering. Server is OR. | ✗ **drop** |
| `isTagsExclusionSupported` (override `false`) | The endpoint has no exclusion parameter; existing override was correct. | ✓ keep false |

Every other parameter probed also works:

| Param | Live probe |
|---|---|
| `OrderValue=title`/`latest`/`update`/`popular`/`titlereverse` | 5 distinct top-3 sets |
| `StatusValue=ongoing`/`completed`/`hiatus` | 40 / 15 / 2 hits respectively |
| `TypeValue=manga`/`manhua`/`manhwa` | 6 / 13 / 66 hits respectively |
| Single-genre `genres_checked[]=3` (Action) | 78 hits |

So the URL builder's `order=` / `StatusValue=` path works as-is, and the single-genre `filter.tags.oneOrThrowIfMany()` path is correct for what the server actually supports.

## What changes

`RizzComic.kt` only, single commit:

- Drop `@Broken("Blocked by Cloudflare challenge")` annotation — no CF challenge is served on any path probed at commit time.
- Drop the now-unused `Broken` import.
- Flip `isMultipleTagsSupported` from `true` to `false` — server treats multiple `genres_checked[]` values as OR, not AND, and this library's semantics require AND for this flag.
- Replace `filter.tags.map { it.key }.forEach { form["genres_checked[]"] = it }` (which silently overwrote on an `ArrayMap`, so only the last tag ever survived) with `filter.tags.oneOrThrowIfMany()?.key?.let { … }` — so we never silently drop user intent when the UI somehow sends more than one.

No other files changed. Parser logic for list/detail/reader is unchanged — base `MangaReaderParser` continues to handle detail page `#chapterlist` extraction and `#readerarea img` page extraction via the existing `selectTestScript`-empty branch.

## 5 QCs

**Vulnerability:** none. This is a boolean flip (`@Broken`), a capability-flag correction (`isMultipleTagsSupported`), and a tightening of the URL-builder (now single-tag-only, using a library helper). No new endpoints hit, no new user input surfaces, no new network calls. The filter tightening *reduces* what's sent to the server — the repeated `genres_checked[]` key was already broken client-side (last-wins in `ArrayMap`) and the library now surfaces that intent explicitly.

**Quality:** evidence-driven. Multi-tag AND-vs-OR-vs-last-wins was disambiguated with a two-genre probe where intersection(4) and union(78) have very different cardinalities, and the order of tags in the POST body was reversed to rule out last-wins (both orderings returned 78, matching union only). Search probe used a known-matching query and a nonsense string for null-result verification. Status/type/order all probed with multiple values confirming distinct result sets.

**Bug risk:** low. The parser is de-facto already running in "single-tag only" mode on the client side because of the `ArrayMap` overwrite. After this PR, that reality is made explicit and the advertised capability matches. Before this PR: user picks Action+Adventure, parser silently sends only Adventure, server returns OR results anyway — user sees unrelated titles with no explanation. After this PR: UI offers single-tag-only, user sees only what the server can actually filter.

**Concern:** one — if RizzFables ever flips the multi-genre semantics to AND server-side, this parser will no longer advertise multi-tag support and will need a one-line flag flip (plus swapping `oneOrThrowIfMany` back to a forEach with a proper multi-value POST). Worth the tradeoff: advertising capabilities the server silently ignores is strictly worse UX.

**Compatibility:** zero impact on other parsers. The base `MangaReaderParser` class is untouched. `MangaParserSource.RIZZCOMIC` enum value is preserved (annotation name unchanged). No public API touched. Build/KSP/CI untouched.

## Test plan

- [x] Live probe `/series` — 88 `.bsx` entries, no CF challenge.
- [x] Live probe `POST /Index/filter_series` (all defaults) — 87-entry JSON array, full metadata shape.
- [x] Live probe `POST /Index/live_search` — search query filters results; nonsense returns empty array.
- [x] Live probe detail page (`r2311170-a-bad-person`) — `#chapterlist` with 129 `<li>` entries carrying `data-num`.
- [x] Live probe chapter page (`chapter-127`) — `#readerarea` with 19 `<img>` pages (base `selectPage` branch).
- [x] Probe multi-tag: Action+Adaptation returns union(78), not intersection(4) — confirms OR not AND.
- [x] Reverse-order multi-tag probe — same union(78), rules out last-wins.
- [x] Order/status/type all probed with distinct result sets per value.
- [x] Grep tree for any external consumer of the old `@Broken` annotation on this class — none.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
