### PR TITLE
fix(cocomic): repair parser and narrow filter capabilities

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/CoComic.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/CoComic.kt
@@ -3,11 +3,19 @@ package org.koitharu.kotatsu.parsers.site.madara.en
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.ContentType
+import org.koitharu.kotatsu.parsers.model.MangaListFilterCapabilities
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.MangaTag
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import org.koitharu.kotatsu.parsers.Broken
 
-@Broken("Blocked by Cloudflare challenge")
 @MangaSourceParser("COCOMIC", "CoComic", "en", ContentType.HENTAI)
 internal class CoComic(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.COCOMIC, "cocomic.co")
+	MadaraParser(context, MangaParserSource.COCOMIC, "cocomic.co") {
+
+	override val filterCapabilities: MangaListFilterCapabilities
+		get() = MangaListFilterCapabilities(
+			isSearchSupported = true,
+		)
+
+	override suspend fun fetchAvailableTags(): Set<MangaTag> = emptySet()
+}


### PR DESCRIPTION
## Summary

Un-`@Broken` the CoComic parser (`cocomic.co`). The `@Broken("Blocked by Cloudflare challenge")` annotation no longer reflects reality — no CF challenge is served on any browse/detail/reader path. Browse/detail/reader all work with base `MadaraParser` selectors untouched, but the site's query-filter backend is unreliable (no genre filter form exposed, empty-result fallback returns the full unfiltered catalog, multi-tag counts collapse against the page cap in non-deterministic ways), so filterCapabilities is narrowed to what was actually verified working: search only.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET cocomic.co/manga/` | 200, 12 `div.page-item-detail` entries (matches base Madara `parseMangaList`); no CF banner |
| `GET cocomic.co/manga/koisuru-psycho-no-shirayuki-kun/` | 200, `#manga-chapters-holder data-id="60669"` present |
| `POST cocomic.co/manga/<slug>/ajax/chapters/` | 200, 42 `<li class="wp-manga-chapter free-chap ">` entries (matches base async-chapter branch) |
| `GET cocomic.co/manga/<slug>/volume-1-chapter-1/` | 200, 37 `<img class="wp-manga-chapter-img ...">` with `data-src` → `img.cocomic.co/.../001.webp` etc. |

Base `MadaraParser` selectors (`parseMangaList` → `div.page-item-detail`, `manga-chapters-holder` async POST, `wp-manga-chapter-img` lazyload) all match the live DOM without parser-level overrides.

## What the live probe showed — filter flags

Every inherited `filterCapabilities` flag was probed against the live server. Only search survives.

| Flag | Live probe | Kept? |
|---|---|---|
| `isSearchSupported` (default `true`) | `?s=dragon&post_type=wp-manga` → 11 title-matching hits, `?s=zzznotexist` → 0 hits. Server honours `s=`. | ✓ **keep** |
| `isMultipleTagsSupported` (default `true`) | `/?s=&post_type=wp-manga&genre[]=action` returns 24 across pages; `genre[]=romance` returns 0 (site uses `/manga-genre/romance/` for the actual taxonomy — 9 titles — and ignores the `genre[]=` query for many slugs). `genre[]=action&genre[]=drama` collapses to the landing page (known Madara "no matches → return full catalog" bug is active here). Cannot verify AND semantics for any genre combination. | ✗ **drop** |
| `isTagsExclusionSupported` (default `!withoutAjax` = `true`) | Unverifiable — driven by the same `genre[]=` param that the server doesn't reliably honour. | ✗ **drop** |
| `isYearSupported` (default `true`) | `?release=2024` and `?release=1999` each return 12 hits capped at page size, sets differ but neither differs from landing in a way that proves filtering rather than ordering. Not enough signal to claim year filter works. | ✗ **drop** |
| `isSearchWithFiltersSupported` (default `true`) | No filter UI on `/manga/` — no `search-advanced-wrap`, no `genre[]` inputs, no genre dropdown. Nothing to combine with search. | ✗ **drop** |
| `isAuthorSearchSupported` (default `false`) | Already off. | ✓ keep false |

`fetchAvailableTags()` is also overridden to return `emptySet()` because the base implementation throws `parseFailed("Root not found")` on this site — neither `header ul.second-menu` nor `div.genres_wrap ul.list-unstyled` exists in the DOM.

The `/manga/` landing page does have real pagination (`/manga/page/2/` → 11 more titles, page 20 still returns 5) and status filtering does honour `status[]=on-going` (1 hit) vs `status[]=end` (6 hits), so the default `availableStates` and base sort URL builder are left untouched.

## What changes

`CoComic.kt` only, single commit:

- Drop `@Broken("Blocked by Cloudflare challenge")` annotation — no CF challenge served on any path at commit time.
- Drop the now-unused `Broken` import.
- Override `filterCapabilities` to enable only `isSearchSupported = true`; everything else falls to the capability default of `false` because the server doesn't reliably honour the inherited URL-builder for those params on this site.
- Override `fetchAvailableTags()` to return `emptySet()` — the base DOM selectors don't exist on this site, and the `genre[]=` URL backend is unreliable anyway.

No other files changed. `MangaParserSource.COCOMIC` enum value is preserved.

## 5 QCs

**Vulnerability:** none. This is a boolean flip (`@Broken`), a capability narrowing (flip four flags from default-true to false), and a tag-source override to empty. No new endpoints hit, no new user input surfaces, no new network calls. Narrowing capabilities *reduces* the attack surface — the parser will no longer send URL params the server doesn't honour.

**Quality:** evidence-driven. Every inherited flag was probed individually against the live server: search disambiguated with a nonsense-query null-result, multi-tag tested for AND-vs-OR with two genre combinations of known distinct cardinalities, year filter tested with 2024 vs 1999, state filter verified as the one URL-builder param that *does* work (and left alone). The `fetchAvailableTags()` base DOM selectors were checked against the live page and confirmed absent (0 matches for `header.second-menu`, `genres_wrap`, or `manga-genre` hrefs on `/manga/`).

**Bug risk:** low. Every behavior touched is verified working or verified broken on the live server at commit time. Capability narrowing is strictly safer than the inherited defaults — before this PR, a user selecting two genres would see random results because the server returns the unfiltered catalog when no manga match; after this PR, the multi-tag UI is simply unavailable on this source.

**Concern:** one — if CoComic ever exposes a proper genre taxonomy filter (like the upstream Madara theme), this parser will be lagging behind what the server supports. The remediation is a one-time reintroduction of base capabilities; no ongoing maintenance burden. Cheap to fix later if/when it matters; meanwhile users get only verified-working functionality instead of misleading UI.

**Compatibility:** zero impact on other parsers. The base `MadaraParser` class is untouched. `MangaParserSource.COCOMIC` enum value is preserved. No public API changed. Build/KSP/CI untouched.

## Test plan

- [x] Live probe `/manga/` → 12 `div.page-item-detail` entries; pagination via `/manga/page/N/` works through at least page 20.
- [x] Live probe detail page (`koisuru-psycho-no-shirayuki-kun`) → `#manga-chapters-holder` with `data-id`; POST to `/ajax/chapters/` → 42 chapter li entries.
- [x] Live probe chapter page → 37 `<img class="wp-manga-chapter-img">` with `data-src` URLs.
- [x] Live probe search: `?s=dragon&post_type=wp-manga` → 11 hits; `?s=zzznotexist` → 0 hits (nonsense-query null check).
- [x] Live probe multi-tag: `genre[]=action&genre[]=drama` collapses to unfiltered landing set → empty-result fallback confirmed → cannot trust AND semantics → drop `isMultipleTagsSupported`.
- [x] Live probe exclusion: `genre[]=-romance` unverifiable on same unreliable endpoint → drop `isTagsExclusionSupported`.
- [x] Live probe year: `release=2024` vs `release=1999` both capped at 12 hits, differ from landing but not diagnostically → drop `isYearSupported`.
- [x] Live probe status: `status[]=on-going` → 1 hit, `status[]=end` → 6 hits → base state filter works, left alone.
- [x] Live probe `m_orderby=latest/trending/new-manga/rating` → four distinct top results → base sort URL builder honoured.
- [x] Verify `fetchAvailableTags()` base DOM selectors against live `/manga/`: no `header ul.second-menu`, no `div.genres_wrap`, no `manga-genre` hrefs → override to `emptySet()` justified.
- [x] Grep tree for any external consumer of the old `Broken`-annotated `CoComic` class → none.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
