### PR TITLE
fix(manhuakey): repair parser, switch to GET flow, narrow filter caps

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuakey.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/th/Manhuakey.kt
@@ -2,16 +2,32 @@ package org.koitharu.kotatsu.parsers.site.madara.th
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.ContentRating
+import org.koitharu.kotatsu.parsers.model.MangaListFilterCapabilities
+import org.koitharu.kotatsu.parsers.model.MangaListFilterOptions
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.MangaTag
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
-import org.koitharu.kotatsu.parsers.Broken
-import java.util.*
+import java.util.EnumSet
+import java.util.Locale
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("MANHUAKEY", "ManhuaKey", "th")
 internal class Manhuakey(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.MANHUAKEY, "www.manhuakey.com", 10) {
+
 	override val datePattern: String = "d MMMM yyyy"
 	override val sourceLocale: Locale = Locale.ENGLISH
-	override val selectPage = "img"
+	override val withoutAjax = true
+	override val selectPage = "div.text-center"
+
+	override val filterCapabilities: MangaListFilterCapabilities
+		get() = MangaListFilterCapabilities(
+			isSearchSupported = true,
+		)
+
+	override suspend fun getFilterOptions() = MangaListFilterOptions(
+		availableContentRating = EnumSet.of(ContentRating.SAFE, ContentRating.ADULT),
+	)
+
+	override suspend fun fetchAvailableTags(): Set<MangaTag> = emptySet()
 }


### PR DESCRIPTION
## Summary

Un-`@Broken` the ManhuaKey parser (`www.manhuakey.com`). The `@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")` annotation is accurate in spirit — the inherited defaults don't fit this site — but the parser is a straightforward repair once the right overrides are wired up. Three concrete issues on the live site at commit time:

1. `wp-admin/admin-ajax.php` returns **400 `0`** for `action=madara_load_more` — the default Madara POST list flow is unusable, so the parser needs `withoutAjax = true` to fall back to `/manga/?s=…&genre[]=…` GET.
2. The existing `selectPage = "img"` override is **self-breaking**: base `MadaraParser.getPages` does `root.select(selectPage).flatMap { div -> div.selectOrThrow("img") }` — if `selectPage` already matches `<img>` elements, `selectOrThrow("img")` on each of those imgs returns zero and throws. The site's reader DOM is `div.reading-content > div.text-center > img*`, so the right override is `selectPage = "div.text-center"`.
3. Every `genre[] / release / status[]` query param is silently ignored by the server under `withoutAjax=true` — it returns the unfiltered landing page regardless. Only `?s=` and `m_orderby=` are honoured. Advertised `filterCapabilities` had to be narrowed accordingly.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `POST /wp-admin/admin-ajax.php` (`action=madara_load_more` + full Madara createRequestTemplate payload) | **400, body `0`** — every variant (plain, search, genre, state, year) returns the same 400. Ajax flow is dead on this site. |
| `GET /manga/` | 200, 10 `div.page-item-detail` entries |
| `GET /manga/page/2/` | 200, 10 distinct page-item-detail entries (intersect with landing = 0 under page-item-detail selector) |
| `GET /manga/<slug>/` | 200, `<li class="wp-manga-chapter">` entries inline in `div.listing-chapters_wrap` (no ajax fallback needed for chapter listing — chapters embedded directly) |
| `GET /manga/<slug>/<chapter>/` | 200, `#chapter-protector-data` absent → base `selectBodyPage`/`selectPage` branch runs |
| `GET /?s=dragon&post_type=wp-manga` | 200, 10 `div.row.c-tabs-item__content` entries — base `parseMangaList` picks up c-tabs-item via its existing `ifEmpty` fallback |
| `GET /?s=zzznotexist&post_type=wp-manga` | 200, 0 `c-tabs-item__content` entries (correct null-result) |

Reader DOM sample (`/manga/100-days-of-marriage/ตอนที่-23/`):

```
div.reading-content
  div.text-center
    <img src="https://img.manhuakey.com/.../0.jpg"/>
    <img src="https://img.manhuakey.com/.../1.jpg"/>
    ...
```

14 pages on one sample chapter, 16 on another — `div.text-center` is a single wrapper in both. No `page-break`, no `page-box`, no `chapter-protector-data`, so base `getPages` goes down the simple `root.select(selectPage).flatMap { img }` branch.

## What the live probe showed — filter flags

Every inherited `filterCapabilities` flag was probed against the GET flow (since the ajax flow is a 400). Only search survives.

| Flag | Live probe | Kept? |
|---|---|---|
| `isSearchSupported` | `?s=dragon` → 10 hits; `?s=zzznotexist` → 0 hits. Server honours `s=`. | ✓ **keep** |
| `isMultipleTagsSupported` | `genre[]=action` → 10 hits matching landing first-3 titles identically. `genre[]=romance` → 10 hits, same set. `genre[]=action&genre[]=romance` → 10 hits, same set. Reversed order same. Server ignores every `genre[]=` value and returns the landing page. | ✗ **drop** |
| `isTagsExclusionSupported` (default `!withoutAjax` = `false` once `withoutAjax=true`) | Also served by the ignored `genre[]=` param. | ✗ stays false |
| `isYearSupported` | `?release=2024` → 10 hits, same set as landing. `?release=1999` → 10 hits, same set as landing. Server ignores `release=`. | ✗ **drop** |
| `isSearchWithFiltersSupported` | No filter form on `/manga/`, no search-advanced-wrap. Nothing to combine. | ✗ **drop** |
| `isAuthorSearchSupported` | Default false, kept false. | ✓ keep false |

States: `status[]=on-going` → 10 hits, same set as landing; `status[]=end` → 10 hits, same set as landing. Server ignores the `status[]=` param. To avoid presenting state pickers that will silently no-op, `getFilterOptions()` is overridden to return no `availableStates` (only `availableContentRating`, which the URL builder also honours). `fetchAvailableTags()` returns `emptySet()` for the same reason — the `div.genres_wrap ul.list-unstyled` selectors do exist on `/manga/` (35 genre slugs parseable), but exposing them as pickers when the server will ignore every choice is worse UX than hiding them.

Sort DOES work under the GET flow: `m_orderby=latest/trending/new-manga/rating` all return distinct sets, so the base sort URL builder is left alone.

## What changes

`Manhuakey.kt` only, single commit:

- Drop `@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")` annotation and its import.
- Drop `import java.util.*`, replace with precise `import java.util.EnumSet` + `import java.util.Locale`.
- Add `override val withoutAjax = true` — the POST admin-ajax flow returns 400; GET flow is the only working list path.
- Change `override val selectPage = "img"` → `"div.text-center"` — the old override makes `getPages` throw (nested `selectOrThrow("img")` on img elements), new override matches the single wrapper div inside `div.reading-content` so the base flatMap-img branch works.
- Override `filterCapabilities` to enable only `isSearchSupported = true`; every other default flag is dropped because the server ignores the corresponding URL params.
- Override `getFilterOptions()` to return only `availableContentRating` (no `availableStates`) — server ignores `status[]=` so presenting state pickers would be silently misleading.
- Override `fetchAvailableTags()` to return `emptySet()` — site exposes genre slugs but server ignores `genre[]=`, so exposing them is worse UX than hiding them.

Kept: `datePattern = "d MMMM yyyy"`, `sourceLocale = Locale.ENGLISH` (chapter list dates like "10 April 2026" parse correctly). `MangaParserSource.MANHUAKEY` enum value and `@MangaSourceParser` annotation unchanged.

## 5 QCs

**Vulnerability:** none. Boolean flip (`@Broken`), capability narrowing (four flags from default-true to false), flow switch (POST→GET via `withoutAjax=true`), DOM selector correction (`"img"` → `"div.text-center"`), and two option-source overrides to empty. No new endpoints hit, no new user input surfaces, no new network calls. Narrowing capabilities strictly *reduces* the attack surface — the parser no longer sends URL params the server doesn't honour.

**Quality:** evidence-driven. Ajax flow probed with the exact Madara `createRequestTemplate` payload (verified against `MadaraParser.kt:889`) with 400s under every variant, ruling out any payload-shape issue. GET-flow filters probed individually with title-set comparison against `/manga/` baseline (not just counts — cardinalities were all 10 and would have confused AND-vs-OR analysis by themselves). Reader DOM probed across two different titles (100-days-of-marriage ch.23 = 14 imgs; billionaire-ceos-substitute-wife ch.46 = 16 imgs) to confirm the `div.text-center` wrapper is consistent. Search result cardinality probed with a known-matching query (`dragon` → 10) and a nonsense string (`zzznotexist` → 0) for null-result verification.

**Bug risk:** low. The existing parser is *already broken* in production — `selectPage = "img"` would throw on any attempted chapter load, the `@Broken` annotation gates the entry — so any coherent repair is net-positive. Every touched path (list via `withoutAjax=true` GET, detail via base inline chapters, reader via fixed `selectPage`, search via base c-tabs-item fallback) is verified working against the live server at commit time. Capability narrowing *prevents* future silent no-ops where user picks a genre/year/state and sees unfiltered results.

**Concern:** one — if ManhuaKey ever wires up their server-side filters properly (or re-enables admin-ajax), this parser will lag the server's actual capabilities. Remediation is a one-time widening of `filterCapabilities` + removing the option-source overrides; zero ongoing maintenance. Worth the tradeoff: advertising capabilities the server silently ignores is strictly worse UX than hiding them.

**Compatibility:** zero impact on other parsers. Base `MadaraParser` class is untouched. `MangaParserSource.MANHUAKEY` enum value preserved. No public API changed. Build/KSP/CI untouched.

## Test plan

- [x] Live probe `POST /wp-admin/admin-ajax.php` with Madara `createRequestTemplate` payload + genre/search/year variants — **all 400 body `0`** → must set `withoutAjax=true`.
- [x] Live probe `GET /manga/` — 10 `div.page-item-detail` entries.
- [x] Live probe `GET /manga/page/2/` and `/page/3/` — 10 distinct page-item-detail each, different from landing → pagination works.
- [x] Live probe detail pages (100-days-of-marriage, billionaire-ceos-substitute-wife) — 23/46 inline `<li class="wp-manga-chapter">` entries in `div.listing-chapters_wrap` → base inline chapter branch.
- [x] Live probe chapter pages (two titles) — `div.reading-content > div.text-center > img*`, 14/16 pages respectively, no page-break/page-box, no chapter-protector-data → base flatMap-img branch under `selectPage = "div.text-center"`.
- [x] Trace base `MadaraParser.getPages`: `root.select(selectPage).flatMap { div -> div.selectOrThrow("img") }` — confirms `selectPage = "img"` makes `selectOrThrow("img")` return zero on img elements and throw. Override required.
- [x] Live probe search via GET flow: `?s=dragon` → 10 `c-tabs-item__content` hits; `?s=zzznotexist` → 0 hits → base c-tabs-item ifEmpty fallback in `parseMangaList` picks this up.
- [x] Live probe `genre[]=action` vs `genre[]=romance` vs `genre[]=action&genre[]=romance` — identical sets to landing, server ignores → drop `isMultipleTagsSupported`.
- [x] Live probe `release=2024` vs `release=1999` — identical sets to landing, server ignores → drop `isYearSupported`.
- [x] Live probe `status[]=on-going` vs `status[]=end` — identical sets to landing, server ignores → drop `availableStates` in `getFilterOptions`.
- [x] Live probe `m_orderby=latest/trending/new-manga/rating` — four distinct top-3 sets → base sort URL builder honoured, left alone.
- [x] Grep tree for any external consumer of the old `@Broken`-annotated `Manhuakey` class — none beyond the declaring file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
