### PR TITLE
fix(likemanga): un-@Broken - no CF challenge, parser matches live DOM

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/likemanga/en/LikeManga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/likemanga/en/LikeManga.kt
@@ -1,12 +1,10 @@
 package org.koitharu.kotatsu.parsers.site.likemanga.en
 
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.likemanga.LikeMangaParser
 
-@Broken("Blocked by Cloudflare")
 @MangaSourceParser("LIKEMANGA", "LikeManga", "en")
 internal class LikeManga(context: MangaLoaderContext) :
 	LikeMangaParser(context, MangaParserSource.LIKEMANGA, "likemanga.ink")


### PR DESCRIPTION
Fixes #330

## Summary

Un-`@Broken` the LikeManga parser (`likemanga.ink`). The `@Broken("Blocked by Cloudflare")` annotation no longer reflects reality — the site serves no Cloudflare challenge on any browse/search/detail/reader/ajax path at commit time, and every selector and URL-builder path in the existing `LikeMangaParser` matches the live DOM without changes. The annotation itself is the bottleneck: it gates the source from being selectable in the app at all, so `@Broken` + an online site = users see exactly what #330 reports.

Zero parser-code changes. One-file, annotation-drop PR.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET likemanga.ink/` | 200, 258 KB, no CF banner, no `Just a moment`, no `cf-mitigated` header, no `Checking your browser` text |
| `GET likemanga.ink/?act=search&f[sortby]=lastest-chap` | 200, **36 `div.card-body div.video` entries** (exactly matches existing parser selector and `pageSize=36`) |
| `GET likemanga.ink/?act=search&…&pageNum=2` | 200, 36 entries, 0 overlap with page 1 |
| `GET likemanga.ink/?act=search&…&pageNum=5` | 200, 36 entries, 0 overlap with pages 1 or 2 — pagination works as the URL-builder expects |
| `GET likemanga.ink/<slug>-<id>/` (detail) | 200, `#nav_list_chapter_id_detail` present, 51 `li.wp-manga-chapter` entries, `#summary_shortened` present, `li.kind` tags and `li.author` both present, `list-info li.othername` alt-title present |
| `GET likemanga.ink/<slug>-<id>/chapter-<N>-<id>/` | 200, no `#next_img_token` (takes the else branch in `getPages`), 124 `<img>` elements inside `.reading-detail` pointing at `https://like.mgread.io/manga/...` |
| `GET likemanga.ink/?act=ajax&code=load_list_chapter&manga_id=32123&page_num=1&chap_id=0&keyword=` | 200, JSON `{"list_chap": "<li…>", "nav": …}` — exactly the shape `loadChapters()` decodes |
| `GET likemanga.ink/genres/` | 200, 1× `ul.nav-genres`, 69 `li` with anchors — exactly what `fetchAvailableTags()` reads |

Every DOM selector, URL parameter, and JSON key the parser currently expects is present in live responses.

## What the live probe showed — filter flags

Every flag the parser currently advertises was re-verified against the live endpoint. None need changing.

| Flag | Live probe | Keep? |
|---|---|---|
| `isSearchSupported` | `f[keyword]=dragon` → 36 distinct dragon-themed titles; `f[keyword]=zzznotexist` → 0 results. | ✓ |
| `isSearchWithFiltersSupported` | `f[keyword]=dragon&f[genres]=action` → 36 items distinct from plain `dragon` and plain `action`; `f[keyword]=dragon&f[status]=complete` → 0 items (vs dragon alone = 36, complete alone = 1, intersection legitimately empty). Server honours combined params. | ✓ |
| `isMultipleTagsSupported` (not set → false) | URL-builder uses `filter.tags.oneOrThrowIfMany()` — single tag only; server URL accepts single `f[genres]=` value. Correct as-is. | ✓ stays false |
| `isTagsExclusionSupported` (not set → false) | No exclusion param in URL-builder; server has no exclusion syntax. | ✓ stays false |
| `isYearSupported` (not set → false) | Correct — no year param. | ✓ stays false |
| `isAuthorSearchSupported` (not set → false) | Correct — no author param. | ✓ stays false |

Sort orders (`lastest-chap` / `lastest-manga` / `top-manga` / `top-day` / `top-week` / `top-month`) all return distinct top-3 sets — the `availableSortOrders` enum + sort URL-builder are intact.

State filter (`f[status]=in-process` → 27 items; `f[status]=complete` → 1 item) works, matching `availableStates = {ONGOING, FINISHED, PAUSED}` mapping in `getFilterOptions()`.

Tag filter (`f[genres]=action` → 36 items with 21 overlap to the latest-chap landing; `f[genres]=romance` → 36 items with 12 overlap) produces distinct sets per genre.

## What changes

`en/LikeManga.kt` only:

- Drop `@Broken("Blocked by Cloudflare")` annotation — no Cloudflare challenge is served on any path at commit time.
- Drop the now-unused `org.koitharu.kotatsu.parsers.Broken` import.

Nothing else changes. No parser logic, no selectors, no URL-builder, no `LikeMangaParser` base class touched. `MangaParserSource.LIKEMANGA` enum value preserved.

## 5 QCs

**Vulnerability:** none. This is a one-line annotation drop on one wrapper class; the underlying `LikeMangaParser` — which handles all network and parsing — is untouched. No new endpoints are hit, no new user input surfaces, no new network calls. The site is plain HTML + a small JSON ajax for chapter pagination, no auth, no credentials, no PII.

**Quality:** evidence-driven. Re-probed every parser path against the live server at commit time: list endpoint with the existing `div.card-body div.video` CSS selector returns exactly 36 cards (matching `pageSize=36`); detail page has every element `getDetails()` reads (`#nav_list_chapter_id_detail`, `#summary_shortened`, `li.kind`, `li.author`, `li.othername`); chapter page takes the `else` branch of `getPages()` and exposes 124 imgs under `.reading-detail`; `/?act=ajax&code=load_list_chapter&…` returns the exact JSON shape `loadChapters()` expects; `/genres/` has the one `ul.nav-genres` with 69 anchors for `fetchAvailableTags()`. Filter flags re-verified individually — `isSearchSupported` with a known-hit query (`dragon`) and a nonsense-query null check (`zzznotexist`), `isSearchWithFiltersSupported` with two different filter combos to confirm server honours combined params, and sort orders with six different `sortby` values producing six distinct top results.

**Bug risk:** very low. The parser's existing selectors and URL-builder are the same as they were when `@Broken` was added; the live site currently honours all of them. The `@Broken` annotation is the gate keeping users from reaching the parser — #330 reports "Cannot open likemanga with VPN or without VPN", which is the exact symptom of an online site with a `@Broken` annotation. The risk of re-enabling a currently-working source is bounded to: if CF reappears, `@Broken` gets re-added in a subsequent PR — same one-line diff in reverse.

**Concern:** one — CF flagging is regional and time-varying, so this change may not fix the symptom for every user in every region. For the majority of users (and for the sandbox running this probe, which hit the site unchallenged across 10+ requests across list/search/detail/reader/ajax/genres paths), the parser works. Regional CF is out of scope; if enough users report renewed CF challenges post-merge, the fix is a one-line re-annotation.

**Compatibility:** zero impact on other parsers. `LikeMangaParser` (the base class used only by this one concrete class) is untouched. `MangaParserSource.LIKEMANGA` enum value preserved. No public API changed. Build/KSP/CI untouched.

## Test plan

- [x] `GET /` — 200, no CF challenge (`Just a moment`, `cf-mitigated`, `Checking your browser` all absent).
- [x] `GET /?act=search&f[sortby]=lastest-chap` — 36 `div.card-body div.video` matches (via BeautifulSoup CSS engine — confirms selector validity, not just regex presence).
- [x] Pagination: `pageNum=2` and `pageNum=5` each return 36 distinct entries (0 overlap with page 1).
- [x] Detail page: `#nav_list_chapter_id_detail` present (maxPageChapter logic engages), 51 `wp-manga-chapter` items, `#summary_shortened` + `li.kind` + `li.author` + `li.othername` all present.
- [x] Ajax chapter endpoint: `/?act=ajax&code=load_list_chapter&manga_id=…&page_num=…` returns JSON with `list_chap` key — matches `loadChapters()` parseJson path.
- [x] Chapter page: no `#next_img_token` → takes `else` branch, 124 imgs under `.reading-detail` with `https://like.mgread.io/manga/…` URLs.
- [x] Search: `f[keyword]=dragon` → 36 dragon-themed titles; `f[keyword]=zzznotexist` → 0 matches (null-result check).
- [x] Search with filters: `f[keyword]=dragon&f[genres]=action` → 36 items distinct from plain dragon/action; `f[keyword]=dragon&f[status]=complete` → 0 items (legitimate empty intersection).
- [x] Sort orders: all six (`lastest-chap`, `lastest-manga`, `top-manga`, `top-day`, `top-week`, `top-month`) return distinct top results.
- [x] State filter: `f[status]=in-process` → 27 items, `f[status]=complete` → 1 item — distinct, state filter works.
- [x] Genres page: `ul.nav-genres` present with 69 `li a` entries — `fetchAvailableTags()` works.
- [x] Grep for other callers of the `LikeManga`/`LikeMangaParser` class tree — only the single `en/LikeManga.kt` wrapper uses it.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
