### PR TITLE
fix(solooscan): mangaCategory Recentes -> Comics, narrow filter opts

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zeistmanga/pt/SolooScan.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/zeistmanga/pt/SolooScan.kt
@@ -2,16 +2,21 @@ package org.koitharu.kotatsu.parsers.site.zeistmanga.pt
 
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
+import org.koitharu.kotatsu.parsers.model.MangaListFilterOptions
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.MangaState
 import org.koitharu.kotatsu.parsers.site.zeistmanga.ZeistMangaParser
-import org.koitharu.kotatsu.parsers.Broken
+import java.util.EnumSet
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("SOLOOSCAN", "SolooScan", "pt")
 internal class SolooScan(context: MangaLoaderContext) :
 	ZeistMangaParser(context, MangaParserSource.SOLOOSCAN, "solooscan.blogspot.com") {
-	override val mangaCategory = "Recentes"
+	override val mangaCategory = "Comics"
 	override val sateOngoing: String = "Lançando"
 	override val sateFinished: String = "Completo"
 	override val sateAbandoned: String = "Dropado"
+
+	override suspend fun getFilterOptions() = MangaListFilterOptions(
+		availableStates = EnumSet.of(MangaState.ONGOING, MangaState.FINISHED, MangaState.ABANDONED),
+	)
 }


### PR DESCRIPTION
## Summary

Un-`@Broken` the SolooScan parser (`solooscan.blogspot.com`). The existing override had `mangaCategory = "Recentes"` — that Blogger label doesn't exist on the blog, so every list-page request returned an empty feed regardless of pagination. The correct label is `Comics`, which tags all 6 manga series on the site. The site itself is alive, serves the Blogger Atom API unchallenged, and every other path the base `ZeistMangaParser` uses (detail page `#clwd` chapter-feed branch, chapter page `#reader img` reader DOM, state-label feeds) matches the live server.

Secondary bug: base `fetchAvailableTags()` does `doc.selectFirstOrThrow("div.filter")` on the blog homepage, but this Blogger theme has no `div.filter` element — so opening the filter UI would throw. Override `getFilterOptions()` to return only `availableStates` (no `availableTags`), sidestepping the missing selector.

Filter flags re-verified against the live API before shipping.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET solooscan.blogspot.com/` | 200, 272 KB, no CF challenge |
| `GET /feeds/posts/default/-/Recentes?alt=json&…` (current code) | 200, **0 entries** — "Recentes" is not a label on this blog |
| `GET /feeds/posts/default/-/Comics?alt=json&…` (fix) | 200, **6 manga series entries** — all 6 manga the site hosts |
| `GET /feeds/posts/default/-/Lançando?alt=json&…` (ONGOING) | 200, 2 series (both Comics-tagged, not Chapter-tagged) |
| `GET /feeds/posts/default/-/Completo?alt=json&…` (FINISHED) | 200, 0 series (no completed manga exists — legitimate empty state) |
| `GET /feeds/posts/default/-/Dropado?alt=json&…` (ABANDONED) | 200, 2 series |
| `GET /feeds/posts/default/-/Comics?…&q=label:Comics+Eu` (search) | 200, 2 matches (`Comece fazendo Login…`, `Eu tenho um milhão…`) |
| `GET /feeds/posts/default/-/Comics?…&q=label:Comics+zzznotexist` | 200, 0 matches (null-result check) |
| `GET /2023/12/Eu-tenho-um-milhao-de-vezes-a-velocidade-de-ataque.html` (detail) | 200, `#clwd > script` with `clwd.run('Eu tenho um milhão de vezes a velocidade de ataque')` — matches base `clwd.run` chapter-feed branch |
| `GET /feeds/posts/default/-/Eu tenho um milhão de vezes a velocidade de ataque?alt=json&max-results=9999` (chapter feed) | 200, **91 chapter entries** |
| `GET /2026/02/capitulo-90.html` (chapter page) | 200, `#reader img` → 6 `blogger.googleusercontent.com` URLs — matches existing `article#reader .separator img` path in base `selectPage` |

Every selector the base parser relies on (except `div.filter` which gets overridden) matches the live site.

## What the live probe showed — filter flags

Base parser declares `isSearchSupported = true`. Every other flag is default-false. Re-verified individually:

| Flag | Live probe | Keep? |
|---|---|---|
| `isSearchSupported` | `q=Eu` → 2 matches, `q=zzznotexist` → 0 (Blogger Atom respects `q=label:Comics+<query>`) | ✓ |
| `isMultipleTagsSupported` (default false) | URL-builder uses `filter.tags.oneOrThrowIfMany()` — server takes single label only. | ✓ stays false |
| `isSearchWithFiltersSupported` (default false) | Blogger Atom has no combined label+state path in getListPage — separate branches per filter. | ✓ stays false |
| `isTagsExclusionSupported` (default false) | No exclusion syntax in URL-builder. | ✓ stays false |
| `isYearSupported` (default false) | No year param. | ✓ stays false |
| `isAuthorSearchSupported` (default false) | No author search. | ✓ stays false |

State filter verified by probing each label endpoint — all three sate* mappings (`Lançando`/`Completo`/`Dropado`) return the expected entries (manga series, not chapter posts).

Tags dropped entirely: base `fetchAvailableTags()` needs `div.filter ul li` on the homepage and this Blogger theme doesn't render it. Rather than invent a tag list, override `getFilterOptions()` to expose only states.

## What changes

`pt/SolooScan.kt` only:

- Drop `@Broken` annotation and its `org.koitharu.kotatsu.parsers.Broken` import.
- `mangaCategory = "Recentes"` → `mangaCategory = "Comics"` (the real label tagging all 6 manga series).
- Override `getFilterOptions()` to return `availableStates` only — skips the `fetchAvailableTags()` call whose `selectFirstOrThrow("div.filter")` would throw on this theme.

Nothing else changes. No parser logic, no base-class touches, no public API changes. `MangaParserSource.SOLOOSCAN` enum value preserved.

## 5 QCs

**Vulnerability:** none. Blogger Atom JSON API is plain HTTPS, no auth/credentials/PII. One string constant change + one method override on one wrapper class. No new endpoints, no new network calls, no new user-input surfaces.

**Quality:** evidence-driven. Every path probed against the live server at commit time. `mangaCategory="Recentes"` returns 0 entries (the bug — confirmed root cause of `@Broken`); `mangaCategory="Comics"` returns 6 entries matching the 6 manga on the site. Detail pages take the `clwd.run` branch in base `loadChapters` (1 matching `#clwd > script` found); chapter feed returns 91 chapter entries for the longest series. Chapter reader pages match `article#reader .separator img` in base `selectPage` (6 blogger.googleusercontent.com URLs on one sample). State labels all yield manga series (not chapter posts). Search with `q=label:Comics+<query>` works for hit and null-result.

**Bug risk:** very low. Root cause is a stale label constant; site is alive and compatible with the base class. Tags-UI throw avoided by narrowing `getFilterOptions()`. Description and author selectors don't match (site uses `<dl><dt>Autor:</dt><dd>...</dd></dl>` pattern, not `#synopsis` / `div.y6x11p`) but both fields fall back to empty strings via null-safety — parser returns a valid Manga object regardless. If the site admin renames the `Comics` label later, the fix is a single-line change in reverse.

**Concern:** one — the site is small (6 manga, actively ran-down). The most recent site-admin banner on the homepage says the previous owner is handing the site to another member; if the successor abandons Blogger or changes the blog theme, the parser will break again. This is a re-check concern, not a correctness concern. For now every endpoint the parser touches is live and returns the expected data shape.

**Compatibility:** zero impact on other parsers. `ZeistMangaParser` (used by other Zeistmanga-based sources in `zeistmanga/id/`, `zeistmanga/es/`, etc.) is untouched. `MangaParserSource.SOLOOSCAN` enum value preserved. No public API changed. Build/KSP/CI untouched.

## Test plan

- [x] `GET /feeds/posts/default/-/Comics?alt=json&max-results=21&start-index=1` — 6 entries, all Comics-tagged manga series.
- [x] `GET /feeds/posts/default/-/Recentes?…` — 0 entries (confirms the current-code bug).
- [x] `GET /feeds/posts/default/-/Lançando?…` — 2 series, both `Comics`-tagged; maps to `MangaState.ONGOING`.
- [x] `GET /feeds/posts/default/-/Completo?…` — 0 series (no finished manga on site; legitimate empty set, not a selector bug).
- [x] `GET /feeds/posts/default/-/Dropado?…` — 2 series; maps to `MangaState.ABANDONED`.
- [x] `q=label:Comics+Eu` — 2 matches; `q=label:Comics+zzznotexist` — 0 matches (null-result).
- [x] Detail page (`2023/12/Eu-tenho-um-milhao…html`) — `#clwd > script` with `clwd.run('Eu tenho um milhão de vezes a velocidade de ataque')` present → base `loadChapters` `clwd.run` branch.
- [x] Chapter feed (`/feeds/posts/default/-/<series-label>?max-results=9999`) — 91 chapter entries, all via `rel=alternate` hrefs.
- [x] Chapter page (`/2026/02/capitulo-90.html`) — 6 `<img>` inside `article#reader .separator` / `#reader` → matches existing base `selectPage`.
- [x] `div.filter` absence on `/` confirmed — override of `getFilterOptions()` is necessary.
- [x] `span[data-status]` present on detail page (base state-selector list) — state detection works.
- [x] `dl:contains(Genre) dd a` present on detail page (base tag-selector list) — detail-page tag population works.
- [x] Grep for other callers of `SolooScan`/`mangaCategory` — only this one file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
