### PR TITLE
fix(komikindo): unbreak parser, drop false isMultipleTagsSupported

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikIndo.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/id/KomikIndo.kt
@@ -6,13 +6,11 @@ import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
 import org.koitharu.kotatsu.parsers.util.*
-import org.koitharu.kotatsu.parsers.Broken
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.EnumSet
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("KOMIKINDO_MOE", "KomikIndo.org", "id", ContentType.HENTAI)
 internal class KomikIndo(context: MangaLoaderContext) :
 	MangaReaderParser(context, MangaParserSource.KOMIKINDO_MOE, "komikindo.ch", pageSize = 30, searchPageSize = 30) {
@@ -29,7 +27,6 @@ internal class KomikIndo(context: MangaLoaderContext) :
 		get() = MangaListFilterCapabilities(
 			isSearchSupported = true,
 			isSearchWithFiltersSupported = true,
-			isMultipleTagsSupported = true,
 		)
 
 	override suspend fun getFilterOptions() = MangaListFilterOptions(


### PR DESCRIPTION
## Summary

Un-`@Broken` the KomikIndo parser (`komikindo.ch`). The site is alive and every selector the wrapper depends on matches the current DOM. Also fix a false `isMultipleTagsSupported=true` flag — the server only honours the **first** `genre[]` parameter, so the multi-tag URL the builder emits silently returns single-tag-filtered results. Narrowing the flag to `false` lets the app enforce one tag at a time instead of producing wrong-but-plausible results.

All other filter capabilities re-verified against the live API before shipping.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET komikindo.ch/` | 200, 228 KB |
| `GET /daftar-manga?order=latest` | 200, 125 KB, **30** `div.animepost` items (matches `selectMangaList`) |
| `GET /daftar-manga?order=latest` — `div.tt h4` count | **30** (matches `selectMangaListTitle`) |
| `GET /komik/<slug>/` (sample: `shura-youjo-no-eiyuutan-…`) | 200, 83 KB — has `div.infox` ✓, `div.entry-content.entry-content-single` ✓, `#chapter_list` ✓, `span.lchx` ✓ |
| `GET /komik/<slug>/` — `Judul Alternatif`, `Pengarang`, `Status: Berjalan`, `Ilustrator` labels | all present in `div.infox > span > b:contains(...)` pattern used by `parseInfo` |
| `GET /<slug>-chapter-N/` (chapter reader) | 200, 82 KB — `div.img-landmine` block present, **42** `onError="this.src='...';"` attributes (matches `getPages` fallback chain) |
| `GET /daftar-manga?title=zelda` | 200, **1** animepost (Zelda no Densetsu) |
| `GET /daftar-manga?title=zzzznotexist` | 200, **0** animeposts (null-result check) |
| `GET /daftar-manga` — `input[name='genre[]']` dropdown options | **49** genre values (`action`, `adventure`, `adult`, `boys-love`, ...) — `fetchAvailableTags()` works |

## What the live probe showed — filter flags

Every flag re-verified individually:

| Flag | Live probe | Before | After |
|---|---|---|---|
| `isSearchSupported` | `title=zelda` → 1 hit, `title=zzzz` → 0 hits | `true` | `true` ✓ |
| `isSearchWithFiltersSupported` | `?genre[]=action&title=zelda` → 1 match (Zelda is in action) | `true` | `true` ✓ |
| `isMultipleTagsSupported` | `?genre[]=action&genre[]=yaoi&order=title` returns **the same first results as `?genre[]=action&order=title` alone** (first results `rank-no-ura-soubi-musou` both times). `yaoi` alone would have returned `179384-solo-leveling` first. Server ignores everything past the first `genre[]`. | `true` ← **BUG** | **`false`** |
| `isTagsExclusionSupported` (default false) | `?genre[]=-action` returns the unfiltered 30-item default — minus-prefix not honoured | inherited default | stays `false` ✓ |
| `isYearSupported` (default false) | No year param on listing | inherited default | stays `false` ✓ |
| `isAuthorSearchSupported` (default false) | No author search | inherited default | stays `false` ✓ |

States verified via `status=Ongoing` / `status=Completed` — both narrow the result set. Content types via `type=Manga`/`Manhwa`/`Manhua` — all three work. Demographics via `demografis[]=josei|seinen|shoujo|shounen` — all four work.

## What changes

`id/KomikIndo.kt` only:

- Drop `@Broken` annotation and its `Broken` import.
- Remove `isMultipleTagsSupported = true` from `filterCapabilities` — server only honours the first `genre[]` param, so advertising multi-tag returns wrong-but-plausible single-tag results.

Nothing else. The existing custom `getListPage`, `getDetails`, `getPages`, `parseInfo`, `parseChapterDate`, `parseRelativeDate`, and `fetchAvailableTags` are all verified to work against the current DOM — zero logic changes.

## 5 QCs

**Vulnerability:** none. komikindo.ch is plain HTTPS; parser issues no credentials, no new network surface. Two-line edit (drop `@Broken` + drop one capability flag).

**Quality:** evidence-driven. Every selector probed against the live server at commit time — `div.animepost` (30 hits), `div.infox` (1 hit on detail), `#chapter_list` (1 hit), `span.lchx` (chapter title `a`), `div.img-landmine` with 42 `onError` fallback src attributes, 49 genre inputs under `ul.dropdown-menu.c4`. Every filter flag retained or removed based on an actual request showing whether the server respects it.

**Bug risk:** very low. The wrapper is already a full override set (`getListPage` builds the URL, `getDetails` walks `#chapter_list`, `getPages` reads `onError` → `src`, `parseInfo` reads each `infox` span). Nothing relies on the `MangaReaderParser` base URL conventions (which use `/manga/` — site uses `/komik/<slug>/`). The only capability-flag change narrows scope (`true` → `false`), so the app will now fall back to single-tag requests that are already proven to work.

**Concern:** one — display label says `"KomikIndo.org"` but actual domain is `komikindo.ch`. The label is user-visible but not part of URL building; leaving it out of scope for this minimum-change PR. Can be a follow-up if the maintainers want to update the display name.

**Compatibility:** zero impact on other parsers. `MangaReaderParser` base is untouched. Only this one file changes. `MangaParserSource.KOMIKINDO_MOE` enum value preserved. No public API, no build changes.

## Test plan

- [x] `GET /daftar-manga?order=latest` — 200, 30 `div.animepost` items.
- [x] `GET /komik/<slug>/` — 200, all parseInfo selectors present (`div.infox`, `Judul Alternatif`, `Pengarang`, `Ilustrator`, `Status`, `genre-info`).
- [x] `GET /<slug>-chapter-1/` — 200, `div.img-landmine` with `onError="this.src='...';"` fallback src attributes (42 on sample).
- [x] `title=zelda` search — 1 hit; `title=zzzznotexist` — 0 hits (search works, null result is clean).
- [x] `genre[]=action&genre[]=yaoi&order=title` vs `genre[]=action&order=title` — identical first results; server ignores 2nd `genre[]` — confirms `isMultipleTagsSupported=false` is correct.
- [x] `genre[]=action&title=zelda` — returns Zelda (confirms `isSearchWithFiltersSupported=true`).
- [x] `status=Ongoing`, `status=Completed`, `type=Manga/Manhwa/Manhua`, `demografis[]=josei/seinen/shoujo/shounen` — all narrow result set.
- [x] `ul.dropdown-menu.c4 li input[name='genre[]']` on `/daftar-manga` — 49 genre options for `fetchAvailableTags()`.
- [x] Grep for other callers of `KOMIKINDO_MOE`/`KomikIndo` — only this one file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
