### PR TITLE
fix(furyosociety): unbreak parser, site + selectors match live DOM

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/FuryoSociety.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/FuryoSociety.kt
@@ -2,7 +2,6 @@ package org.koitharu.kotatsu.parsers.site.fr
 
 import kotlinx.coroutines.coroutineScope
 import org.jsoup.nodes.Document
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.ErrorMessages
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
@@ -15,7 +14,6 @@ import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("FURYOSOCIETY", "FuryoSociety", "fr")
 internal class FuryoSociety(context: MangaLoaderContext) :
 	SinglePageMangaParser(context, MangaParserSource.FURYOSOCIETY) {


### PR DESCRIPTION
## Summary

Un-`@Broken` the FuryoSociety parser (`furyosociety.com`). The site is alive and every selector the custom parser depends on matches the current DOM. No logic changes — just drop the `@Broken` annotation and its `Broken` import.

Filter capabilities re-verified against the live site before shipping (parser declares `MangaListFilterCapabilities()` with zero flags and throws `SEARCH_NOT_SUPPORTED` on query — no filter probing needed because there are no flags to validate).

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET furyosociety.com/` (NEWEST/UPDATED path) | 200, 67 KB — `div.container-tight.latest table tr` present with **50 rows**, each with `/series/<slug>/` href + cover `img` (matches `container-tight.latest table tr` fallback branch in `getList`) |
| `GET furyosociety.com/mangas` (ALPHABETICAL path) | 200, 147 KB — `div.fs-card-container` present (8 hits), `div.grid-item-container` present (**148 items** — every manga series), `div.media-body` (74 hits — card title container). Matches primary `getList` selector path |
| `GET /series/<slug>/` (detail page, sample `angel-densetsu`) | 200, 82 KB — `div.fs-comic-description` ✓, `div.list.fs-chapter-list` ✓, `div.element` under chapter list ✓ (178 hits), `div.title a` with `/read/<slug>/<lang>/<vol>/<ch>/` href ✓, `div.meta_r` with `"Il y a 1 an"` text ✓ (matches `parseChapterDate` `WordSet("il y a").startsWith(d)` branch), `div.name` with chapter name ✓ |
| `GET /read/<slug>/<lang>/<vol>/<ch>/` (reader, sample `angel-densetsu/fr/15/84/`) | 200, 33 KB — `div.main-img` present with **9** `<img>` descendants (`getPages` descendant selector `div.main-img img` returns all chapter pages) |

## What the live probe showed — filter flags

Parser declares:

```kotlin
override val filterCapabilities: MangaListFilterCapabilities
    get() = MangaListFilterCapabilities()

override suspend fun getFilterOptions() = MangaListFilterOptions()
```

Zero flags, zero options. Search throws `SEARCH_NOT_SUPPORTED` on `filter.query`. Nothing to validate against the live API — the parser intentionally advertises no filtering capability, so the app never requests any.

Sort orders (`ALPHABETICAL` → `/mangas`, `UPDATED` → `/` root) both verified against the live site above.

## What changes

`fr/FuryoSociety.kt` only:

- Drop `@Broken` annotation.
- Drop `import org.koitharu.kotatsu.parsers.Broken`.

Nothing else. No logic changes. `MangaParserSource.FURYOSOCIETY` enum value preserved.

## 5 QCs

**Vulnerability:** none. Plain-HTTPS French fansub site (Furyō/Street/Yakuza/Underground translations since 2008). Parser issues no credentials, no new network surface. Two-line edit (drop annotation + drop import).

**Quality:** evidence-driven. Every selector probed against the live server at commit time. `/mangas` returns 148 `grid-item-container` items (every series on the site); `/` returns 50 `table tr` rows in `container-tight.latest` (the fallback branch). Detail page returns 178 `div.element` rows in `fs-chapter-list` with `/read/<slug>/...` chapter URLs and `"Il y a 1 an"` relative-date strings matching the French date parser. Reader page returns 9 images under `div.main-img`.

**Bug risk:** very low. The parser is a `SinglePageMangaParser` with no pagination surface, no filter surface, and no search surface — zero capability flags to get wrong. Every override path (`getList`, `getDetails`, `getChapters`, `getPages`, `parseChapterDate`, `parseRelativeDate`) exercised against the live DOM. Relative date strings all begin with "Il y a" which hits the `.startsWith(d)` branch in `parseChapterDate` cleanly.

**Concern:** none for correctness. Parser is a minimal custom implementation for a small fansub site with ~148 series. `/mangas` returns the full catalog in one page (no pagination needed — correct choice for `SinglePageMangaParser`). No `adult-text` flag on any sample page — `contentRating` falls back to `ContentRating.SAFE`, which is appropriate.

**Compatibility:** zero impact on other parsers. `SinglePageMangaParser` base untouched. Only this one file changes. `MangaParserSource.FURYOSOCIETY` enum value preserved. No public API, no build changes.

## Test plan

- [x] `GET /mangas` — 200, 148 `div.grid-item-container` items (full catalog).
- [x] `GET /` — 200, 50 rows under `div.container-tight.latest table` (fallback branch).
- [x] `GET /series/angel-densetsu/` — 200, `div.fs-comic-description` + `div.list.fs-chapter-list` present, 178 `div.element` chapter rows, each with `div.title a` → `/read/…` URL.
- [x] Chapter-date format `"Il y a 1 an"` → matches `parseChapterDate` `WordSet("il y a").startsWith(d)` → `parseRelativeDate` → `Calendar.YEAR -1` ✓.
- [x] `GET /read/angel-densetsu/fr/15/84/` — 200, 9 `<img>` inside `div.main-img` (reader pages).
- [x] Grep for other callers of `FURYOSOCIETY`/`FuryoSociety` — only this one file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
