### PR TITLE
fix(anibel): unbreak parser, GraphQL API + every query match parser

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/be/AnibelParser.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu.parsers.site.be
 import androidx.collection.ArraySet
 import org.json.JSONArray
 import org.json.JSONObject
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
@@ -19,7 +18,6 @@ import org.koitharu.kotatsu.parsers.util.nullIfEmpty
 import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
 import java.util.*
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("ANIBEL", "Anibel", "be")
 internal class AnibelParser(context: MangaLoaderContext) : AbstractMangaParser(context, MangaParserSource.ANIBEL) {
 


### PR DESCRIPTION
## Summary

Un-`@Broken` the AnibelParser (`anibel.net`). The Belarusian anime/manga site's GraphQL endpoint is alive and every query the parser issues returns clean data matching the parser's expectations. No logic changes — just drop the `@Broken` annotation and its `Broken` import.

All filter capabilities re-verified against the live API before shipping.

## What the live probe showed — API queries

Every GraphQL query the parser emits was run against `https://anibel.net/graphql`:

| Query | Result |
|---|---|
| `getMediaList(offset:0, limit:5, mediaType:manga, filters:{})` | 200, 5 docs with `mediaId`/`title.be`/`slug`/`mediaType`/`status` ✓ |
| `getMediaList` with `filters:{genres:["romance"]}` | 200, 10 docs all containing `romance` in `genres` ✓ |
| `getFilters(mediaType:manga) { genres }` | 200, **34** genre slugs returned (`action`, `adventure`, `comedy`, `drama`, `romance`, `shounen`, `shoujo`, `yuri`, `seinen`, `josei`, …) ✓ |
| `media(mediaType:manga, slug:"Golden-Hour")` | 200, full `title.be`/`title.alt`/`description.be`/`status`/`poster`/`rating`/`genres` ✓ |
| `chapters(mediaId:"…", offset:0, limit:99999)` | 200, chapter docs with `id`/`chapter`/`released` ✓ |
| `chapter(slug:"Golden-Hour", chapter:1)` | 200, `images[]` with `large`/`thumbnail` keys ✓ |
| `search(query:"detective", limit:60)` | 200, mixed manga + anime results with `mediaType` field ✓ (parser filters to `manga` via `mapJSONNotNull`) |

## What the live probe showed — filter flags

| Flag | Live probe | Before | After |
|---|---|---|---|
| `isSearchSupported` | `search(query:"detective")` → 5+ hits incl. "Дэтэктыў ужо памёр"; null queries safe | `true` | `true` ✓ |
| `isMultipleTagsSupported` | `filters:{genres:["romance","drama"]}` returns union of both tag result-sets (OR semantics). `isMultipleTagsSupported` flag only asserts the server **accepts** multiple tags — it does, and produces meaningful results. | `true` | `true` ✓ |
| `isSearchWithFiltersSupported` (default `false`) | Schema's `search` query takes only `query`/`limit` — no filter args. Correct that it stays `false`. | inherited | stays `false` ✓ |
| `isTagsExclusionSupported` (default `false`) | Schema's `filters` arg has no `excludeGenres`. Correct. | inherited | stays `false` ✓ |
| `isYearSupported` (default `false`) | No year param on `getMediaList`. | inherited | stays `false` ✓ |
| `isAuthorSearchSupported` (default `false`) | No author search. | inherited | stays `false` ✓ |

Pagination verified: `offset:0, limit:20` and `offset:20, limit:20` return disjoint mediaId sets (0 overlap, 40 total unique).

## What changes

`be/AnibelParser.kt` only:

- Drop `@Broken` annotation.
- Drop `import org.koitharu.kotatsu.parsers.Broken`.

Nothing else. All 7 GraphQL queries (`getMediaList` unfiltered, `getMediaList` with genre filter, `getFilters`, `media`, `chapters`, `chapter`, `search`) verified intact. `MangaParserSource.ANIBEL` enum value preserved.

## 5 QCs

**Vulnerability:** none. Plain-HTTPS Belarusian anime/manga aggregator — parser issues no credentials, no new network surface. Two-line edit (drop `@Broken` + drop `Broken` import).

**Quality:** evidence-driven. Every GraphQL query the parser emits was run against the live endpoint and returned the exact shape the parser deserialises: `mediaId`, `title.be`, `title.alt[]`, `description.be`, `status` (`ongoing`/`finished`), `poster`, `rating`, `genres[]`, `chapters.docs[].id/chapter/released`, `chapter.images[].large/thumbnail`. `getFilters` returns 34 real genre slugs for `fetchAvailableTags()`.

**Bug risk:** very low. `AnibelParser` is a full `AbstractMangaParser` subclass using GraphQL exclusively (no HTML selectors to rot). The sole API surface is `webClient.graphQLQuery("https://$domain/graphql", request)` — a single, narrow interface. Every field dereferenced by `mapJSON`/`getString`/`getJSONObject` is present in live responses.

**Concern:** one — `search(query:…)` returns both `anime` and `manga` entries; parser correctly filters via `mapJSONNotNull` with a `type != "manga"` early-return. Sampled live search: `"detective"` → 5 results, first two are anime (filtered out), third is manga `"Дэтэктыў і варажбітка"` (kept). Filtering logic works as intended.

**Compatibility:** zero impact on other parsers. `AbstractMangaParser` base is untouched. Only this one file changes. `MangaParserSource.ANIBEL` enum value preserved. No public API, no build changes.

## Test plan

- [x] `getMediaList(offset:0, limit:20, mediaType:manga, filters:{})` — 200, 20 docs ✓.
- [x] `getMediaList(offset:20, limit:20, mediaType:manga, filters:{})` — 200, 20 disjoint docs (pagination clean) ✓.
- [x] `getMediaList` with `filters:{genres:["romance","drama"]}` — 200, 10 docs all containing romance and/or drama (OR union semantics, matches `isMultipleTagsSupported=true` advertisement) ✓.
- [x] `getFilters(mediaType:manga)` — 34 genre slugs for `fetchAvailableTags()` ✓.
- [x] `media(mediaType:manga, slug:"Golden-Hour")` — full detail payload ✓.
- [x] `chapters(mediaId:…)` — returns chapter docs with all required fields ✓.
- [x] `chapter(slug:…, chapter:1)` — returns `images[].large`/`images[].thumbnail` for `getPages` ✓.
- [x] `search(query:"detective")` — mixed results; parser's `mapJSONNotNull` filters to `manga` only ✓.
- [x] Grep for other callers of `ANIBEL`/`AnibelParser` — only this one file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
