### PR TITLE
fix(onma): unbreak parser, drop false isSearchWithFiltersSupported

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mmrcms/ar/Onma.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mmrcms/ar/Onma.kt
@@ -3,7 +3,6 @@ package org.koitharu.kotatsu.parsers.site.mmrcms.ar
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.jsoup.nodes.Document
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.*
@@ -11,12 +10,17 @@ import org.koitharu.kotatsu.parsers.site.mmrcms.MmrcmsParser
 import org.koitharu.kotatsu.parsers.util.*
 import java.util.*
 
-@Broken("Site is online but parser is broken — layout/API changed, needs rewrite")
 @MangaSourceParser("ONMA", "Onma", "ar")
 internal class Onma(context: MangaLoaderContext) :
 	MmrcmsParser(context, MangaParserSource.ONMA, "onma.me") {
 
 	override val sourceLocale: Locale = Locale.ENGLISH
+
+	override val filterCapabilities: MangaListFilterCapabilities
+		get() = MangaListFilterCapabilities(
+			isSearchSupported = true,
+		)
+
 	override val selectState = "h3:contains(الحالة) .text"
 	override val selectAlt = "h3:contains(أسماء أخرى) .text"
 	override val selectAut = "h3:contains(المؤلف) .text"


### PR DESCRIPTION
## Summary

Un-`@Broken` the Onma parser (`onma.me`, Arabic, MMRCMS-based). The site is alive and every selector in the wrapper and base `MmrcmsParser` path resolves against the current DOM. Also narrow `filterCapabilities` to honest values — the live server silently ignores the `alpha=` search param when `cat=` is set, so `isSearchWithFiltersSupported = true` (inherited from `MmrcmsParser`) is a false advertisement that would return tag-only results when the app requests search-within-tag.

## What the live probe showed — paths

| Endpoint | Result |
|---|---|
| `GET /filterList/?page=1&author=&tag=&alpha=&cat=&sortBy=views&asc=false` | 200, 27 KB, **18** `div.chapter-container` items, each with `a.thumbnail` href to `/manga/<slug>`, `h5.media-heading > a > strong` title, `img` cover, rating `span` (e.g. `4.29`) ✓ |
| `GET /filterList` pages 2 and 5 | 200, 18 items each — pagination works ✓ |
| `GET /manga/one-piece-/` (detail) | 200, 1 MB — `div.panel-body` ✓, `div.well` (description) ✓, `h3:contains(الحالة)` ✓ with `<div class="text"><span class="label label-success">مستمرة</span></div>`, `h3:contains(المؤلف)` ✓, `h3:contains(التصنيفات)` ✓ with `<a>` genre links, `ul.chapters` ✓ with 952 `li` rows, each with `<a href="/manga/<slug>/<n>">` + `div.date-chapter-title-rtl` (952 hits, format `dd MMM. yyyy` e.g. `23 Apr. 2026`) ✓ |
| `GET /manga/one-piece-/1181` (reader) | 200, 181 KB — `div#all` present with **12** `<img>` descendants (matches base `selectPage = "div#all img"`) ✓ |
| `GET /manga-list/` | 200, `ul.list-category` present with **34** `li > a` entries, each with `cat=<id>` href (e.g. `cat=1` → أكشن) — `fetchAvailableTags()` works ✓ |
| `GET /filterList` with `alpha=zzxxyy` (null query) | 200, 66 B, 0 items — null-result clean ✓ |

State keyword `مستمرة` on the detail page is already in the base `ongoing` set. `مكتملة` (finished) is already in the `finished` set.

## What the live probe showed — filter flags

| Flag | Live probe | Before | After |
|---|---|---|---|
| `isSearchSupported` | `alpha=one` → 8 hits (One Piece, One Punch Man, One Day I Became a Princess, …); `alpha=zzxxyy` → 0 | inherited `true` | `true` ✓ |
| `isSearchWithFiltersSupported` | `alpha=one&cat=1&sortBy=name` returns **the same 18 slugs as `cat=1&sortBy=name` alone** (`against-the-gods`, `akame-ga-kill`, `akatsuki-no-yona`, …). Search-alone for `one` returns 8 different slugs (`one-piece-`, `0ne_punch_man`, `one-day-i-became-a-princess`, …). Zero intersection between the two result sets — server ignores `alpha=` entirely when `cat=` is set. | inherited `true` ← **BUG** | **`false`** |
| `isMultipleTagsSupported` (default `false`) | URL builder uses `oneOrThrowIfMany()` on `filter.tags` — only single tag honoured | inherited | stays `false` ✓ |
| `isTagsExclusionSupported` / `isYearSupported` / `isAuthorSearchSupported` (defaults `false`) | No `cat=-N` exclusion, no year param, no author param | inherited | stay `false` ✓ |

## What changes

`ar/Onma.kt` only:

- Drop `@Broken` annotation.
- Drop `import org.koitharu.kotatsu.parsers.Broken`.
- Override `filterCapabilities` to `MangaListFilterCapabilities(isSearchSupported = true)` — removes the inherited but-live-broken `isSearchWithFiltersSupported = true`.

Nothing else. All Onma-specific overrides (`parseMangaList`, `getDetails`, the Arabic `select*` header labels) are verified against the current DOM — zero logic changes to scraping code.

## 5 QCs

**Vulnerability:** none. Plain-HTTPS Arabic MMRCMS site; parser issues no credentials, no new network surface. Three-line edit (drop `@Broken` + drop `Broken` import + override `filterCapabilities`).

**Quality:** evidence-driven. Every selector probed against the live server at commit time — 18 `chapter-container` on list, 1 `div.panel-body` + `div.well` on detail, 952 `ul.chapters > li` rows with matching anchors + dates, 12 `img` under `div#all` on reader, 34 `cat=N` options on `/manga-list`. Every filter-flag retained or removed based on an actual request showing whether the server respects it; `isSearchWithFiltersSupported = true` demonstrably returns the wrong result-set (tag-only results) when both params are sent, and is removed.

**Bug risk:** very low. The wrapper only overrides scraping selectors + adds a capability override. `MmrcmsParser` base logic (URL building, pagination, date parsing, tag option parsing) untouched. The narrowed `filterCapabilities` only reduces advertised surface — the app will now route search-within-tag through the standard single-source fallback path instead of requesting a combined URL that silently returns tag-only results.

**Concern:** one — the per-manga `rating` is parsed via `div.selectFirstOrThrow("span").ownText().toFloatOrNull()?.div(5f)`. On live list HTML, the first `<span>` inside each `chapter-container` has ownText `"4.29"` (from the raty/jraty plugin label), which parses cleanly to `0.858`. This matches the intended 0..1 scale. No rating-format drift from the expected `N.N / 5.0` format.

**Compatibility:** zero impact on other parsers. `MmrcmsParser` base is untouched — other MMRCMS subclasses keep their current `isSearchWithFiltersSupported = true` advertisement, which I have not probed. Only this one file changes. `MangaParserSource.ONMA` enum value preserved. No public API, no build changes.

## Test plan

- [x] `GET /filterList/?page=N` for pages 1, 2, 5 — 200, 18 `div.chapter-container` items per page.
- [x] `GET /manga/one-piece-/` — 200, all Onma-specific selectors present (`div.panel-body`, `h3:contains(الحالة)`, `h3:contains(المؤلف)`, `h3:contains(التصنيفات)`, `h3:contains(أسماء أخرى)`); base chapter-list selectors present (`ul.chapters` with 952 `li` rows, `div.date-chapter-title-rtl` × 952).
- [x] `GET /manga/one-piece-/1181` — 200, `div#all` with 12 `<img>` (reader pages).
- [x] `alpha=one` search — 8 hits; `alpha=zzxxyy` — 0 hits (search works, null result is clean).
- [x] `alpha=one&cat=1` vs `cat=1` alone — identical first results; server ignores `alpha=` — confirms `isSearchWithFiltersSupported=false` is the honest flag.
- [x] `/manga-list/` — 34 `ul.list-category li > a` entries (`cat=1`..`cat=34`) for `fetchAvailableTags()`.
- [x] Chapter date `"23 Apr. 2026"` — matches base `datePattern = "dd MMM. yyyy"` under `sourceLocale = Locale.ENGLISH`.
- [x] State `"مستمرة"` → in base `ongoing` set; `"مكتملة"` → in base `finished` set.
- [x] Grep for other callers of `ONMA`/`Onma` — only this one file.
- [ ] `./gradlew assemble` — can't run in this sandbox; CI will confirm on push.
