### PR TITLE
fix(contributing): document WBMD scam-dump + Madara-skin parking patterns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,51 @@ and improved error messages.
 
 ## Writing your parser
 
+### Before you start — check the site isn't a scam dump
+
+A small but real category of "manga sites" you may encounter aren't real sites
+at all — they're paid-service static dumps that masquerade as live manga sites
+to monetise via demo paywalls or ad redirects. A parser submitted against one
+of these will work for the first few chapters and then fall over (or worse,
+funnel users to a scam page). Two patterns we've seen in this repo:
+
+- **Wayback Machine Downloader (WBMD) demo dumps** — the homepage looks like a
+  perfectly normal Madara/MangaReader/etc. site (real `wp-content`,
+  `page-item-detail` cards, looking-correct `/manga/<slug>/` URLs), but the
+  per-chapter HTML files are static `capitulo-N.html` / `chapter-N.html`
+  documents that contain the literal string `The DEMO version only includes 4 pages`
+  with a link to `waybackmachinedownloader.com/en/buy-wayback-machine-downloader-recover/`.
+  Three parsers in this repo (Manhuasy, Daprob, ManhwaPlus) hit this pattern
+  in 2026 after their original domains were abandoned by the legitimate
+  operators — the contributors who originally added those parsers were not at
+  fault; the domains rotted out from under them.
+- **Domain parking with Madara skin** — a sales-park or ad-redirector renders
+  what looks like a Madara homepage (10-20 stub items with `page-item-detail`
+  cards), but every `/page/N/`, `/wp-admin/admin-ajax.php`, search and filter
+  query 404s or returns identical bytes regardless of input. Detail pages are
+  1-2 KB stubs with no chapter list.
+
+**Before opening a PR for a new parser:**
+
+1. Hit the proposed reader URL for at least one chapter. If the response body
+   contains the string `wayback machine downloader`, **do not submit**.
+2. Open `/page/2/` (or whatever the parser's pagination URL is). If it
+   returns the same bytes as `/page/1/`, or 404s, the site is a frozen
+   snapshot — don't submit.
+3. Issue a query that you know should change the result-set (e.g.
+   `?s=zzznoresults`). If the response is byte-identical to the unfiltered
+   homepage, the search is silently ignored — don't claim
+   `isSearchSupported = true`.
+4. Look at the network panel for an Apache `mod_autoindex` listing
+   (`<title>Index of /...</title>`) anywhere in the chapter delivery path.
+   That's a static file dump, not a working CMS.
+
+If you find one of these patterns on a parser that's already merged, open an
+issue rather than silently disabling it — historical context matters for
+deciding whether to remove or annotate `@Broken`.
+
+### Live-API check
+
 So, you want to create a parser, that will provide access to manga from a website.
 First, you should explore a website to learn about API availability.
 If it does not contain any documentation about


### PR DESCRIPTION
## Summary

Document the **Wayback Machine Downloader (WBMD) scam-dump** pattern and the **Madara-skinned domain-parking** pattern in `CONTRIBUTING.md`, so future parser submissions can be screened for these at PR-review time.

## Background

The multi-framework re-audit that produced PRs #360, #361, #362 surfaced a pattern that wasn't previously documented in this repo: **three of the parsers currently in `master`** point at domains that have been hijacked by `waybackmachinedownloader.com` — a paid service that scrapes Wayback Machine snapshots of dead manga sites, re-hosts the static dump on a re-purchased domain, and monetises via a "DEMO version only includes 4 pages" paywall.

The smoking gun is the literal string **`The DEMO version only includes 4 pages`** plus a link to **`waybackmachinedownloader.com/en/buy-wayback-machine-downloader-recover/`** in the per-chapter HTML files (`capitulo-N.html` / `chapter-N.html`). The homepage of these dumps looks completely legitimate (real `wp-content` and `page-item-detail` cards, looking-correct `/manga/<slug>/` URLs), so a casual probe — or a site that was legitimate when its parser was first written — will not flag it.

The three parsers affected are removed in PR #361 (`Manhuasy`, `Daprob`, `ManhwaPlus`). All three were originally committed in mid-2023 by `devi <github.uqmqu@aleeas.com>` (a long-standing contributor with 322+ commits) when the sites were almost certainly real. The rot is in the domains, not the contributors. **This PR is a process fix, not a finger-pointing exercise.**

## What changes

`CONTRIBUTING.md` gains a new section under `## Writing your parser`:

- `### Before you start — check the site isn't a scam dump`
- Lists the two scam patterns with concrete fingerprints
- Names the three affected parsers (Manhuasy, Daprob, ManhwaPlus) so the lesson is concrete
- 4-step pre-submission checklist:
  1. Hit a chapter URL; check body for `wayback machine downloader` string.
  2. Hit `/page/2/`; verify it differs from `/page/1/`.
  3. Issue a query that should return zero (`?s=zzznoresults`); verify the response differs from the unfiltered homepage (proves search isn't silently ignored).
  4. Watch the network panel for `<title>Index of /...</title>` in the chapter path (= Apache `mod_autoindex` static dump).

The four checks can be run in 60 seconds with curl + grep. Cheap, fast, and would have caught all three of the WBMD scam parsers before they merged.

The original "Writing your parser" introduction is preserved verbatim under a new `### Live-API check` subheading so the existing flow isn't disrupted.

## 5 QCs

**Vulnerability:** none. Documentation-only change.

**Quality:** evidence-driven. The four-step checklist was distilled from the actual diagnostic procedure that caught the three WBMD scams and the 35 parking-domain cases in PR #361. Each step takes seconds and would have prevented the relevant subset of the parser tree's current rot.

**Bug risk:** zero. Markdown only.

**Concern:** one — adding a "before you submit" gate slightly raises the barrier to entry for first-time contributors. The wording stays in the cooperative voice ("the contributors who originally added those parsers were not at fault; the domains rotted out from under them") so it doesn't read as an accusation against past contributors.

**Compatibility:** zero impact on parser code or tests.

## Test plan

- [x] Markdown lint: `CONTRIBUTING.md` still renders correctly (no broken nested lists, code spans, or links).
- [x] All three named parsers (Manhuasy, Daprob, ManhwaPlus) are factually currently `@Broken` in `master` and currently in PR #361's removal set — references are accurate.
- [x] The `wayback machine downloader` string substring check works against the live `daprob.com/manga/<slug>/capitulo-N.html` response (verified during the audit).
- [x] Each numbered checklist item works with plain curl — no JS engine, no headless browser, no per-site tooling required.
