### PR TITLE
fix: restore chapter dates for french parsers

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiOrigines.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiOrigines.kt
@@ -32,6 +32,7 @@ internal class HentaiOrigines(context: MangaLoaderContext) :
 	override val selectChapter = "li.wp-manga-chapter, div.chapter-item"
 
 	private val chapterDateFormatFr = ThreadLocal.withInitial { SimpleDateFormat(datePattern, sourceLocale) }
+	private val chapterDateFormatFrDayFirst = ThreadLocal.withInitial { SimpleDateFormat("d MMMM yyyy", sourceLocale) }
 	private val chapterDateFormatEn = ThreadLocal.withInitial { SimpleDateFormat(datePattern, Locale.ENGLISH) }
 	private val chapterDateTimeFormatIso = ThreadLocal.withInitial { SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US) }
 
@@ -108,8 +109,7 @@ internal class HentaiOrigines(context: MangaLoaderContext) :
 			val a = li.selectFirstOrThrow("a")
 			val href = a.attrAsRelativeUrl("href")
 			val chapterTitle = (a.selectFirst("p")?.text() ?: a.ownText()).trim().ifEmpty { null }
-			val dateText = li.selectFirst("a.c-new-tag")?.attr("title")
-				?: li.selectFirst(selectDate)?.text()
+			val dateText = extractDateText(li)
 
 			MangaChapter(
 				id = generateUid(href),
@@ -156,10 +156,21 @@ internal class HentaiOrigines(context: MangaLoaderContext) :
 		val parsedFr = chapterDateFormatFr.get().parseSafe(normalizedRaw)
 		if (parsedFr != 0L) return parsedFr
 
+		val parsedFrDayFirst = chapterDateFormatFrDayFirst.get().parseSafe(normalizedRaw)
+		if (parsedFrDayFirst != 0L) return parsedFrDayFirst
+
 		val parsedEn = chapterDateFormatEn.get().parseSafe(normalizedRaw)
 		if (parsedEn != 0L) return parsedEn
 
 		return chapterDateTimeFormatIso.get().parseSafe(normalizedRaw)
+	}
+
+	private fun extractDateText(li: Element): String? {
+		return li.selectFirst("a.c-new-tag")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff a[title]")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".chapter-release-date > i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(selectDate)?.text()?.trim()?.ifEmpty { null }
 	}
 
 	private fun startOfDay(daysAgo: Int): Long {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOrigines.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/MangasOrigines.kt
@@ -32,6 +32,7 @@ internal class MangasOrigines(context: MangaLoaderContext) :
 	override val selectChapter = "li.wp-manga-chapter, div.chapter-item"
 
 	private val chapterDateFormatFr = ThreadLocal.withInitial { SimpleDateFormat(datePattern, sourceLocale) }
+	private val chapterDateFormatFrDayFirst = ThreadLocal.withInitial { SimpleDateFormat("d MMMM yyyy", sourceLocale) }
 	private val chapterDateFormatEn = ThreadLocal.withInitial { SimpleDateFormat(datePattern, Locale.ENGLISH) }
 	private val chaptersCache = object : LinkedHashMap<String, List<MangaChapter>>(32, 0.75f, true) {
 		override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<MangaChapter>>?): Boolean {
@@ -108,8 +109,7 @@ internal class MangasOrigines(context: MangaLoaderContext) :
 			val a = li.selectFirstOrThrow("a")
 			val href = a.attrAsRelativeUrl("href")
 			val chapterTitle = (a.selectFirst("p")?.text() ?: a.ownText()).trim().ifEmpty { null }
-			val dateText = li.selectFirst("a.c-new-tag")?.attr("title")
-				?: li.selectFirst(selectDate)?.text()
+			val dateText = extractDateText(li)
 
 			MangaChapter(
 				id = generateUid(href),
@@ -148,7 +148,20 @@ internal class MangasOrigines(context: MangaLoaderContext) :
 			return startOfDay(daysAgo = 0)
 		}
 		val parsedFr = chapterDateFormatFr.get().parseSafe(normalizedRaw)
-		return if (parsedFr != 0L) parsedFr else chapterDateFormatEn.get().parseSafe(normalizedRaw)
+		if (parsedFr != 0L) return parsedFr
+
+		val parsedFrDayFirst = chapterDateFormatFrDayFirst.get().parseSafe(normalizedRaw)
+		if (parsedFrDayFirst != 0L) return parsedFrDayFirst
+
+		return chapterDateFormatEn.get().parseSafe(normalizedRaw)
+	}
+
+	private fun extractDateText(li: Element): String? {
+		return li.selectFirst("a.c-new-tag")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff a[title]")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".chapter-release-date > i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(selectDate)?.text()?.trim()?.ifEmpty { null }
 	}
 
 	private fun startOfDay(daysAgo: Int): Long {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScanHentaiMenu.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/ScanHentaiMenu.kt
@@ -39,7 +39,9 @@ internal class ScanHentaiMenu(context: MangaLoaderContext) :
 	override val selectTestAsync = "#manga-chapters-holder li.wp-manga-chapter"
 
 	private val chapterDateFormatFr = ThreadLocal.withInitial { SimpleDateFormat(datePattern, sourceLocale) }
+	private val chapterDateFormatFrDayFirst = ThreadLocal.withInitial { SimpleDateFormat("d MMMM yyyy", sourceLocale) }
 	private val chapterDateFormatEn = ThreadLocal.withInitial { SimpleDateFormat(datePattern, Locale.ENGLISH) }
+	private val chapterDateFormatShort = ThreadLocal.withInitial { SimpleDateFormat("dd/MM/yy", sourceLocale) }
 
 	private val chaptersCache = object : LinkedHashMap<String, List<MangaChapter>>(32, 0.75f, true) {
 		override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<MangaChapter>>?): Boolean {
@@ -206,8 +208,7 @@ internal class ScanHentaiMenu(context: MangaLoaderContext) :
 			val chapterTitle = (a.selectFirst("p")?.text() ?: a.ownText()).trim().ifEmpty { null }
 			val chapterTitleLower = chapterTitle?.lowercase(Locale.ROOT).orEmpty()
 			val hrefLower = href.lowercase(Locale.ROOT)
-			val dateText = li.selectFirst("a.c-new-tag")?.attr("title")
-				?: li.selectFirst(selectDate)?.text()
+			val dateText = extractDateText(li)
 
 			MangaChapter(
 				id = generateUid(href),
@@ -233,7 +234,21 @@ internal class ScanHentaiMenu(context: MangaLoaderContext) :
 		val normalizedRaw = raw?.trim()?.replace('\u00a0', ' ')?.ifEmpty { return 0L } ?: return 0L
 		val frDate = parseChapterDate(chapterDateFormatFr.get(), normalizedRaw)
 		if (frDate != 0L) return frDate
+
+		val frDayFirstDate = parseChapterDate(chapterDateFormatFrDayFirst.get(), normalizedRaw)
+		if (frDayFirstDate != 0L) return frDayFirstDate
+
 		return parseChapterDate(chapterDateFormatEn.get(), normalizedRaw)
+			.takeIf { it != 0L }
+			?: parseChapterDate(chapterDateFormatShort.get(), normalizedRaw)
+	}
+
+	private fun extractDateText(li: Element): String? {
+		return li.selectFirst("a.c-new-tag")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff a[title]")?.attr("title")?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".timediff i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(".chapter-release-date > i")?.text()?.trim()?.ifEmpty { null }
+			?: li.selectFirst(selectDate)?.text()?.trim()?.ifEmpty { null }
 	}
 
 	private fun parseChapterNumber(

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/MangaReaderParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/MangaReaderParser.kt
@@ -17,6 +17,7 @@ import org.koitharu.kotatsu.parsers.util.*
 import java.text.SimpleDateFormat
 import java.util.Base64
 import java.util.EnumSet
+import java.util.Locale
 
 internal abstract class MangaReaderParser(
 	context: MangaLoaderContext,
@@ -175,7 +176,6 @@ internal abstract class MangaReaderParser(
 	protected open val selectChapter = "#chapterlist > ul > li"
 	override suspend fun getDetails(manga: Manga): Manga {
 		val docs = webClient.httpGet(manga.url.toAbsoluteUrl(domain)).parseHtml()
-		val dateFormat = SimpleDateFormat(datePattern, sourceLocale)
 		val chapters = docs.select(selectChapter).mapChapters(reversed = true) { index, element ->
 			val url = element.selectFirst("a")?.attrAsRelativeUrlOrNull("href") ?: return@mapChapters null
 			MangaChapter(
@@ -185,12 +185,19 @@ internal abstract class MangaReaderParser(
 				number = index + 1f,
 				volume = 0,
 				scanlator = null,
-				uploadDate = dateFormat.parseSafe(element.selectFirst(".chapterdate")?.text()),
+				uploadDate = parseChapterDate(element.selectFirst(".chapterdate")?.text()),
 				branch = null,
 				source = source,
 			)
 		}
 		return parseInfo(docs, manga, chapters)
+	}
+
+	protected open fun parseChapterDate(date: String?): Long {
+		val sourceDate = SimpleDateFormat(datePattern, sourceLocale).parseSafe(date)
+		if (sourceDate != 0L) return sourceDate
+
+		return SimpleDateFormat(datePattern, Locale.ENGLISH).parseSafe(date)
 	}
 
 	protected open val detailsDescriptionSelector = "div.entry-content"


### PR DESCRIPTION
This fixes missing chapter dates for:
  - MangasOrigines
  - Hentai Origines
  - X-MANGA
  - SushiScan.fr

  Changes:
  - Extract Madara chapter dates from the actual `.timediff` / `title` nodes used by the sites.
  - Add support for French day-first dates like `26 avril 2026`.
  - Add support for X-MANGA short dates like `01/04/26`.
  - Add English fallback parsing for MangaReader-based sources such as SushiScan.fr, which currently exposes dates like `June 5, 2025`.