### PR TITLE
fix(OlimpoScans): use data-original for lazy-loaded images

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/es/OlimpoScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fmreader/es/OlimpoScans.kt
@@ -19,7 +19,7 @@ internal class OlimpoScans(context: MangaLoaderContext) :
 		val fullUrl = ("/" + chapter.url).toAbsoluteUrl(domain)
 		val doc = webClient.httpGet(fullUrl).parseHtml()
 		return doc.select(selectPage).map { img ->
-			val url = ("/proxy.php?link=" + img.requireSrc()).toRelativeUrl(domain)
+			val url = img.attr("data-original").toRelativeUrl(domain)
 			MangaPage(
 				id = generateUid(url),
 				url = url,


### PR DESCRIPTION
## Description

Fixes the  method in OlimpoScans parser. The chapter pages use lazy loading with  attribute for images, but the parser was using  which returned the placeholder image ().

### Changes
- Changed from proxy wrapper to direct image URL extraction using  attribute
- Images are now served directly from 

### Testing
Tested with curl:
```bash
curl -s "https://leerolimpo.com/leer-la-venganza-del-sabueso-de-sangre-de-hierro-capitulo-161.html" | grep -oP "data-original='[^']+'" | head -5
```

**PLEASE READ THIS**

I confirm that:

- [ ] All relevant issues have been mentioned in the PR description (e.g., "Closes #???")
- [ ] I have built the library with these changes to update the number of available sources in the [Summary](https://github.com/YakaTeam/kotatsu-parsers/blob/master/.github/summary.yaml) file
- [ ] I have removed `@Broken` annotation if the issue causing it to malfunction has been resolved (N/A - this is a bug fix)
- [ ] I have added a special type to `MangaSourceParser` annotation if necessary (e.g., "`type = ContentType.HENTAI`") (N/A)
- [ ] I have added a specific language code to `MangaSourceParser` annotation if the source is not multilingual (e.g., `vi`) (N/A)
- [x] I have not changed the parser class name and ensured it does not conflict with any existing class
- [ ] All declared sort orders and filters in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` are properly implemented in `getList()` OR `getListPage()` function
- [x] I have followed the instructions and parser class skeleton provided in [this CONTRIBUTING guide](https://github.com/YakaTeam/kotatsu-parsers/blob/master/CONTRIBUTING.md)
- [x] This PR only creates / edits to a single source; any more than that will be automatically rejected by reviewers

**TESTING**

I confirm that:

- [ ] I have tested the parser for syntax errors by compiling the class with the library
- [ ] I have tested the parser by compiling, building, and packaging it with the debug application
- [ ] All sort orders and filters declared in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` work correctly in the debug application
- [ ] `getList()` OR `getListPage()` and `getDetails()` functions retrieve all necessary information
- [x] `getPages()` function successfully retrieves all images from the source

> [!IMPORTANT]
> - You must provide accurate information before creating a pull request
> - Select only the tasks you have completed and leave blank if you haven't done so
> - This information will be verified against data retrieved from that source by the reviewers.

---

### Source Name (Language)
OlimpoScans (Spanish)

### Related Issues
N/A

### Description
Bug fix: changed getPages to use data-original attribute for lazy-loaded chapter images instead of src attribute which returns placeholder.