### PR TITLE
fix: restore MangaMoins chapter images

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/MangaMoins.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/fr/MangaMoins.kt
@@ -3,6 +3,10 @@ package org.koitharu.kotatsu.parsers.site.fr
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.json.JSONObject
+import org.jsoup.HttpStatusException
+import org.jsoup.nodes.Document
+import org.jsoup.parser.Parser
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
@@ -23,11 +27,11 @@ import org.koitharu.kotatsu.parsers.util.generateUid
 import org.koitharu.kotatsu.parsers.util.parseHtml
 import org.koitharu.kotatsu.parsers.util.parseJson
 import org.koitharu.kotatsu.parsers.util.toAbsoluteUrl
-import org.json.JSONObject
-import org.jsoup.nodes.Document
 import org.koitharu.kotatsu.parsers.network.CommonHeaders
+import java.net.HttpURLConnection
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import java.text.Normalizer
 import java.util.EnumSet
 import java.util.LinkedHashMap
 import java.util.Locale
@@ -49,6 +53,8 @@ internal class MangaMoins(context: MangaLoaderContext) :
 			return size > PAGES_CACHE_SIZE
 		}
 	}
+	@Volatile
+	private var sessionWarmUpTime = 0L
 
 	override fun getRequestHeaders(): Headers = super.getRequestHeaders().newBuilder()
 		.add(CommonHeaders.REFERER, "https://$domain/")
@@ -69,7 +75,7 @@ internal class MangaMoins(context: MangaLoaderContext) :
 				}
 			}
 			.build()
-		val json = webClient.httpGet(url).parseJson()
+		val json = fetchApiJson(url)
 		if (json.optString("status").equals("error", ignoreCase = true)) {
 			throw ParseException(json.optString("message"), url.toString())
 		}
@@ -77,13 +83,14 @@ internal class MangaMoins(context: MangaLoaderContext) :
 		val list = ArrayList<Manga>(data.length())
 		for (i in 0 until data.length()) {
 			val jo = data.optJSONObject(i) ?: continue
-			val title = jo.optString("title").trim()
+			val title = decodeHtml(jo.optString("title"))
 			if (title.isEmpty()) continue
-			val slug = title.toMangaSlug()
-			val coverFolder = jo.optString("cover_folder").trim()
-			val coverUrl = coverFolder.takeIf { it.isNotEmpty() }?.let {
-				"https://$domain/files/scans/$it/thumbnail.webp"
-			}
+			val slug = jo.optString("mangaSlug").trim().ifEmpty { title.toMangaSlug() }
+			val coverUrl = jo.optString("cover").trim().ifEmpty {
+				jo.optString("cover_folder").trim().takeIf { it.isNotEmpty() }?.let {
+					"https://$domain/files/scans/$it/thumbnail.webp"
+				}.orEmpty()
+			}.ifEmpty { null }?.toAbsoluteUrl(domain)
 			list += Manga(
 				id = generateUid(slug),
 				title = title,
@@ -109,14 +116,12 @@ internal class MangaMoins(context: MangaLoaderContext) :
 		}
 		val json = fetchMangaJson(manga)
 		val info = json.optJSONObject("info")
-		val detailsTitle = info?.optString("title").orEmpty().ifBlank { manga.title }
+		val detailsTitle = decodeHtml(info?.optString("title")).ifBlank { manga.title }
 		val chapters = parseChapters(json).ifEmpty { manga.chapters.orEmpty() }
-		val description = info?.optString("description").orEmpty().trim().ifEmpty { null }
-		val authors = parseAuthors(info?.optString("author")).ifEmpty { manga.authors }
+		val description = decodeHtml(info?.optString("description")).ifEmpty { null }
+		val authors = parseAuthors(decodeHtml(info?.optString("author"))).ifEmpty { manga.authors }
 		val coverUrl = info?.optString("cover").orEmpty().trim().ifEmpty { null }?.toAbsoluteUrl(domain)
-		val canonicalSlug = extractSlugFromMangaUrl(manga.url)
-			?: extractSlugFromMangaUrl(manga.publicUrl)
-			?: detailsTitle.toMangaSlug()
+		val canonicalSlug = buildDetailsCandidates(manga).firstOrNull() ?: detailsTitle.toMangaSlug()
 		val details = manga.copy(
 			title = detailsTitle,
 			publicUrl = "https://$domain/manga/$canonicalSlug",
@@ -138,7 +143,24 @@ internal class MangaMoins(context: MangaLoaderContext) :
 		synchronized(pagesCache) {
 			pagesCache[cacheKey]?.let { return it }
 		}
+		val folder = extractScanFolder(chapter.url)
+		if (folder != null) {
+			val apiPages = fetchPagesFromApi(folder, chapter.source, chapter.url.toAbsoluteUrl(domain))
+			if (apiPages.isNotEmpty()) {
+				synchronized(pagesCache) {
+					pagesCache[cacheKey] = apiPages
+				}
+				return apiPages
+			}
+		}
 		val doc = webClient.httpGet(chapter.url.toAbsoluteUrl(domain)).parseHtml()
+		val readerPages = parsePagesFromReader(doc, chapter.source)
+		if (readerPages.isNotEmpty()) {
+			synchronized(pagesCache) {
+				pagesCache[cacheKey] = readerPages
+			}
+			return readerPages
+		}
 		val preloaded = doc.select("link[rel=preload][as=image]")
 			.mapNotNull { sanitizePageUrl(it.attr("href")) }
 			.distinct()
@@ -156,8 +178,7 @@ internal class MangaMoins(context: MangaLoaderContext) :
 			}
 			return pages
 		}
-		val folder = extractScanFolder(chapter.url) ?: return emptyList()
-		val pages = parsePagesFromScript(doc, folder, chapter.source)
+		val pages = folder?.let { parsePagesFromScript(doc, it, chapter.source) }.orEmpty()
 		if (pages.isNotEmpty()) {
 			synchronized(pagesCache) {
 				pagesCache[cacheKey] = pages
@@ -180,7 +201,15 @@ internal class MangaMoins(context: MangaLoaderContext) :
 				.addPathSegments("api/v1/manga")
 				.addQueryParameter("manga", title)
 				.build()
-			val json = webClient.httpGet(url).parseJson()
+			val json = try {
+				fetchApiJson(url)
+			} catch (e: HttpStatusException) {
+				if (e.statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+					continue
+				} else {
+					throw e
+				}
+			}
 			val score = scoreDetailsResponse(json)
 			if (score > bestScore) {
 				bestScore = score
@@ -198,16 +227,16 @@ internal class MangaMoins(context: MangaLoaderContext) :
 		val result = ArrayList<MangaChapter>(ja.length())
 		for (i in ja.length() - 1 downTo 0) {
 			val jo = ja.optJSONObject(i) ?: continue
-			val folder = jo.optString("folder").trim()
-			if (folder.isEmpty()) continue
-			val chapterNumber = parseChapterNumber(jo.optString("num"), folder)
-			val chapterTitle = buildChapterTitle(chapterNumber, jo.optString("title"))
+			val slug = jo.optString("slug").trim().ifEmpty { jo.optString("folder").trim() }
+			if (slug.isEmpty()) continue
+			val chapterNumber = parseChapterNumber(jo.optString("num"), slug)
+			val chapterTitle = buildChapterTitle(chapterNumber, decodeHtml(jo.optString("title")))
 			result += MangaChapter(
-				id = generateUid(folder),
+				id = generateUid(slug),
 				title = chapterTitle,
 				number = chapterNumber,
 				volume = 0,
-				url = "/scan/$folder",
+				url = "/scan/$slug",
 				scanlator = null,
 				uploadDate = jo.optLong("time", 0L) * 1000L,
 				branch = null,
@@ -215,6 +244,68 @@ internal class MangaMoins(context: MangaLoaderContext) :
 			)
 		}
 		return result.distinctBy { it.url }
+	}
+
+	private suspend fun fetchPagesFromApi(slug: String, source: MangaSource, referer: String): List<MangaPage> {
+		val url = HttpUrl.Builder()
+			.scheme("https")
+			.host(domain)
+			.addPathSegments("api/v1/scan")
+			.addQueryParameter("slug", slug)
+			.build()
+		val json = fetchApiJson(url, referer)
+		val pagesBaseUrl = normalizePageUrl(json.optString("pagesBaseUrl").trim()).ifEmpty { return emptyList() }
+		val pagesCount = json.optInt("pageNumbers", 0)
+		if (pagesCount <= 0) return emptyList()
+		val baseUrl = if (pagesBaseUrl.endsWith('/')) pagesBaseUrl else "$pagesBaseUrl/"
+		return (1..pagesCount).mapNotNull { page ->
+			val pageName = page.toString().padStart(2, '0')
+			sanitizePageUrl("$baseUrl$pageName.webp")
+		}.distinct().map { pageUrl ->
+			MangaPage(
+				id = generateUid(pageUrl),
+				url = pageUrl,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+
+	private fun parsePagesFromReader(doc: Document, source: MangaSource): List<MangaPage> {
+		val imageUrls = doc.select("img.reader-manga-page[src], #readerContent img[src], main img[src]")
+			.mapNotNull { sanitizePageUrl(it.attr("src")) }
+			.distinct()
+		if (imageUrls.isEmpty()) return emptyList()
+		val totalPages = doc.getElementById("readerTotalPages")?.text()?.trim()?.toIntOrNull() ?: imageUrls.size
+		val pages = if (imageUrls.size == 1 && totalPages > 1) {
+			generateReaderPageUrls(imageUrls.first(), totalPages).ifEmpty { imageUrls }
+		} else {
+			imageUrls
+		}
+		return pages.map { pageUrl ->
+			MangaPage(
+				id = generateUid(pageUrl),
+				url = pageUrl,
+				preview = null,
+				source = source,
+			)
+		}
+	}
+
+	private fun generateReaderPageUrls(firstPageUrl: String, pagesCount: Int): List<String> {
+		val url = firstPageUrl.toHttpUrlOrNull() ?: return emptyList()
+		val lastSegment = url.pathSegments.lastOrNull() ?: return emptyList()
+		val match = PAGE_IMAGE_NAME_REGEX.matchEntire(lastSegment) ?: return emptyList()
+		val width = match.groupValues[1].length
+		val extension = match.groupValues[2]
+		val baseUrl = firstPageUrl.substringBeforeLast('/', missingDelimiterValue = "")
+			.takeIf { it.isNotEmpty() }
+			?.plus('/')
+			?: return emptyList()
+		return (1..pagesCount).mapNotNull { page ->
+			val pageName = page.toString().padStart(width, '0')
+			sanitizePageUrl("$baseUrl$pageName$extension")
+		}
 	}
 
 	private fun parsePagesFromScript(doc: Document, folder: String, source: MangaSource): List<MangaPage> {
@@ -231,29 +322,80 @@ internal class MangaMoins(context: MangaLoaderContext) :
 				page to mtime
 			}
 			.sortedBy { it.first }
-				.mapNotNull { (page, mtime) ->
-					val pageName = page.toString().padStart(2, '0')
-					sanitizePageUrl("/files/scans/$folder/$pageName.png?v=$mtime")
-				}
-				.distinct()
-			return pairs.map { pageUrl ->
+			.mapNotNull { (page, mtime) ->
+				val pageName = page.toString().padStart(2, '0')
+				sanitizePageUrl("/files/scans/$folder/$pageName.png?v=$mtime")
+			}
+			.distinct()
+		return pairs.map { pageUrl ->
 			MangaPage(
 				id = generateUid(pageUrl),
 				url = pageUrl,
 				preview = null,
 				source = source,
 			)
-			}.toList()
+		}.toList()
 	}
 
 	private fun sanitizePageUrl(raw: String?): String? {
-		val candidate = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+		val candidate = raw?.trim()?.takeIf { it.isNotEmpty() }?.let(::normalizePageUrl) ?: return null
 		val absolute = candidate.toAbsoluteUrl(domain)
 		val url = absolute.toHttpUrlOrNull() ?: return null
 		if (url.queryParameterNames.contains("v") && url.queryParameter("v").isNullOrBlank()) {
 			return null
 		}
 		return url.newBuilder().build().toString()
+	}
+
+	private fun normalizePageUrl(url: String): String {
+		// The site reader strips this decoy prefix from API page URLs before loading images.
+		return url.replace(PAGE_URL_DECOY_PREFIX, "")
+	}
+
+	private suspend fun fetchApiJson(url: HttpUrl, referer: String = "https://$domain/"): JSONObject {
+		var lastError: HttpStatusException? = null
+		for (attempt in 0 until API_SESSION_ATTEMPTS) {
+			ensureApiSession(force = attempt > 0)
+			try {
+				val json = webClient.httpGet(url, apiHeaders(referer)).parseJson()
+				if (json.isSessionError() && attempt + 1 < API_SESSION_ATTEMPTS) {
+					continue
+				}
+				return json
+			} catch (e: HttpStatusException) {
+				if (e.statusCode != HttpURLConnection.HTTP_FORBIDDEN || attempt + 1 >= API_SESSION_ATTEMPTS) {
+					throw e
+				}
+				lastError = e
+			}
+		}
+		throw lastError ?: ParseException("Cannot load API response", url.toString())
+	}
+
+	private suspend fun ensureApiSession(force: Boolean) {
+		val now = System.currentTimeMillis()
+		if (!force && now - sessionWarmUpTime < SESSION_REFRESH_INTERVAL) return
+		webClient.httpGet("https://$domain/").parseHtml()
+		sessionWarmUpTime = now
+	}
+
+	private fun apiHeaders(referer: String): Headers = Headers.Builder()
+		.add(CommonHeaders.ACCEPT, "application/json, text/plain, */*")
+		.add(CommonHeaders.REFERER, referer)
+		.add(CommonHeaders.SEC_FETCH_DEST, "empty")
+		.add(CommonHeaders.SEC_FETCH_MODE, "cors")
+		.add(CommonHeaders.SEC_FETCH_SITE, "same-origin")
+		.build()
+
+	private fun JSONObject.isSessionError(): Boolean {
+		val error = optString("error")
+		return optInt("code") == API_FORBIDDEN_CODE ||
+			error.equals("Forbidden", ignoreCase = true) ||
+			error.equals("Unauthorized", ignoreCase = true)
+	}
+
+	private fun decodeHtml(raw: String?): String {
+		return Parser.unescapeEntities(raw.orEmpty().trim(), false).trim()
 	}
 
 	private fun parseState(status: String?): MangaState? {
@@ -312,11 +454,15 @@ internal class MangaMoins(context: MangaLoaderContext) :
 	}
 
 	private fun buildDetailsCandidates(manga: Manga): List<String> {
+		val urlSlug = extractSlugFromMangaUrl(manga.url)
+		val publicUrlSlug = extractSlugFromMangaUrl(manga.publicUrl)
 		val ordered = listOfNotNull(
-			extractSlugFromMangaUrl(manga.url)?.toMangaTitle(),
-			extractSlugFromMangaUrl(manga.publicUrl)?.toMangaTitle(),
-			legacyMangaTitle(manga.url),
-			manga.title.trim().takeIf { it.isNotEmpty() },
+			legacyMangaSlug(urlSlug),
+			urlSlug?.toMangaSlug(),
+			legacyMangaSlug(publicUrlSlug),
+			publicUrlSlug?.toMangaSlug(),
+			legacyMangaSlug(manga.url),
+			manga.title.trim().takeIf { it.isNotEmpty() }?.toMangaSlug(),
 		).distinctBy { it.lowercase(Locale.ROOT) }
 
 		return when {
@@ -347,12 +493,8 @@ internal class MangaMoins(context: MangaLoaderContext) :
 	}
 
 	private fun buildDetailsCacheKey(manga: Manga): String {
-		return (
-			extractSlugFromMangaUrl(manga.url)
-				?: extractSlugFromMangaUrl(manga.publicUrl)
-				?: manga.title.toMangaSlug()
-			)
-			.lowercase(Locale.ROOT)
+		return buildDetailsCandidates(manga).firstOrNull()?.lowercase(Locale.ROOT)
+			?: manga.title.toMangaSlug().lowercase(Locale.ROOT)
 	}
 
 	private fun extractScanFolder(url: String): String? {
@@ -377,34 +519,46 @@ internal class MangaMoins(context: MangaLoaderContext) :
 		return null
 	}
 
-	private fun String.toMangaTitle(): String = URLDecoder.decode(this, StandardCharsets.UTF_8.name()).replace('+', ' ').trim()
-
-	private fun String.toMangaSlug(): String = lowercase(Locale.ROOT)
+	private fun String.toMangaTitle(): String = URLDecoder.decode(this, StandardCharsets.UTF_8.name())
+		.replace('+', ' ')
 		.trim()
-		.replace(WHITESPACES_REGEX, "+")
 
-	private fun legacyMangaTitle(url: String): String? = when (url.uppercase(Locale.ROOT)) {
-		"OP" -> "One Piece"
-		"LCDL" -> "Les Carnets de l'apothicaire"
-		"JKM" -> "Jujutsu Kaisen Modulo"
-		"OPC" -> "One Piece Colo"
-		"LDS" -> "L'Atelier des Sorciers"
+	private fun String.toMangaSlug(): String {
+		val normalized = Normalizer.normalize(decodeHtml(toMangaTitle()), Normalizer.Form.NFD)
+			.replace(DIACRITICS_REGEX, "")
+		return normalized.lowercase(Locale.ROOT)
+			.replace(MANGA_SLUG_SEPARATOR_REGEX, "_")
+			.trim('_')
+	}
+
+	private fun legacyMangaSlug(raw: String?): String? = when (raw?.uppercase(Locale.ROOT)) {
+		"OP" -> "one_piece"
+		"LCDL" -> "les_carnets_de_l_apothicaire"
+		"JKM" -> "jujutsu_kaisen_modulo"
+		"OPC" -> "one_piece_colo"
+		"LDS" -> "l_atelier_des_sorciers"
 		else -> null
 	}
 
 	private companion object {
 
 		private const val API_LIMIT = 12
+		private const val API_FORBIDDEN_CODE = 101
+		private const val API_SESSION_ATTEMPTS = 2
+		private const val SESSION_REFRESH_INTERVAL = 60L * 60L * 1000L
 		private const val UNKNOWN_MANGA_TITLE = "Unknown manga"
-			private const val DETAILS_SCORE_EMPTY = 0
-			private const val DETAILS_SCORE_WITH_METADATA = 1
-			private const val DETAILS_SCORE_WITH_CHAPTERS = 2
-			private const val DETAILS_CACHE_SIZE = 200
-			private const val PAGES_CACHE_SIZE = 400
-			private val AUTHORS_SPLIT_PATTERN = Regex("[,&/]")
-		private val WHITESPACES_REGEX = Regex("\\s+")
+		private const val DETAILS_SCORE_EMPTY = 0
+		private const val DETAILS_SCORE_WITH_METADATA = 1
+		private const val DETAILS_SCORE_WITH_CHAPTERS = 2
+		private const val DETAILS_CACHE_SIZE = 200
+		private const val PAGES_CACHE_SIZE = 400
+		private val AUTHORS_SPLIT_PATTERN = Regex("[,&/]")
+		private val DIACRITICS_REGEX = Regex("\\p{Mn}+")
+		private val MANGA_SLUG_SEPARATOR_REGEX = Regex("[^a-z0-9]+")
 		private val CHAPTER_NUMBER_REGEX = Regex("(\\d+(?:\\.\\d+)?)$")
 		private val IMAGE_MTIMES_BLOCK = Regex("imageMtimes\\s*=\\s*\\{([^}]*)\\}")
 		private val IMAGE_MTIMES_ENTRY = Regex("[\"']?([0-9]+)[\"']?\\s*:\\s*([0-9]+)")
+		private val PAGE_IMAGE_NAME_REGEX = Regex("(\\d+)(\\.[^./?#]+)")
+		private const val PAGE_URL_DECOY_PREFIX = "4445xcsltlesnoobsarretezdevolernoscansmerci123891b"
 	}
 }


### PR DESCRIPTION
## Summary
  - Fix MangaMoins chapter image URLs after the site added a decoy prefix in `pagesBaseUrl`.
  - Strip the same prefix as the official reader before generating page URLs.
  - Apply the normalization in `sanitizePageUrl` so API and reader fallbacks both resolve valid images.
